### PR TITLE
add disk_path setting for mounted disk

### DIFF
--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -20,6 +20,10 @@ locals {
       value = random_id.cookie_hash.hex
     }
 
+    disk_path = {
+      value = var.disk_path
+    }
+
     enc_password = {
       value = random_id.enc_password.hex
     }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -186,3 +186,9 @@ variable "bypass_preflight_checks" {
   type        = bool
   description = "Allow the TFE application to start without preflight checks. Replicated defaults this to false."
 }
+
+variable "disk_path" {
+  default     = null
+  type        = string
+  description = "Absolute path to a directory on the instance to store Terraform Enteprise data. Valid for mounted disk installations."
+}


### PR DESCRIPTION
## Background

Add `disk_path` setting for use with mounted disk mode.

[Asana task](https://app.asana.com/0/1181500399442529/1201454602171841/f)

## How has this been tested?

I tested this successfully locally with [this branch](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/compare/ah-mounted-disk?expand=1) of the module which is waiting for [this branch](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/142) to be merged.

## This PR makes me feel

![nested](https://media.giphy.com/media/xTeWOVI8shjIDTq9Yk/giphy.gif)
