### PR TITLE
Redis Port and Use TLS

### DIFF
--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -41,7 +41,6 @@ module "settings" {
   # Redis
   redis_host                = local.redis.host
   redis_pass                = local.redis.pass
-  redis_enable_non_ssl_port = local.redis.enable_non_ssl_port
   redis_use_tls             = local.redis.use_tls
   redis_use_password_auth   = local.redis.use_password_auth
 

--- a/modules/settings/tfe_redis_config.tf
+++ b/modules/settings/tfe_redis_config.tf
@@ -9,7 +9,7 @@ locals {
     }
 
     redis_port = {
-      value = var.redis_enable_non_ssl_port == true ? "6379" : "6380"
+      value = var.redis_use_tls == true ? "6380" : "6379"
     }
 
     redis_use_password_auth = {

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -64,12 +64,6 @@ variable "redis_pass" {
   description = "The Primary Access Key for the Redis Instance. Must be set to the password of an external Redis instance if the instance requires password authentication."
 }
 
-variable "redis_enable_non_ssl_port" {
-  default     = null
-  type        = bool
-  description = "If true, the external Redis instance will use port 6379, otherwise 6380"
-}
-
 variable "redis_use_password_auth" {
   default     = null
   type        = bool
@@ -79,7 +73,7 @@ variable "redis_use_password_auth" {
 variable "redis_use_tls" {
   default     = null
   type        = bool
-  description = "Redis service requires TLS"
+  description = "Redis service requires TLS. If true, the external Redis instance will use port 6380, otherwise 6379."
 }
 
 # Azure


### PR DESCRIPTION
## Background

This PR updates `redis_port` to infer its value based on `redis_use_tls`, which obviates the inclusion of the `redis_enable_non_ssl_port` variable.

Relates https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/142

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/QaN5BogCfpp6hQ4GA9/giphy.gif?cid=5a38a5a2tk2lk6r16b6d3dpfm5neiwjsl8l38cqbeybp9mpb&rid=giphy.gif&ct=g)
