### PR TITLE
Add test proxy init fixture

### DIFF
--- a/fixtures/test_proxy_init/README.md
+++ b/fixtures/test_proxy_init/README.md
@@ -1,0 +1,8 @@
+# Test Proxy Init
+
+This fixture provides initialization logic for proxies used in tests:
+
+- mitmproxy
+- squid
+
+Ubuntu is the only supported operating system.

--- a/fixtures/test_proxy_init/README.md
+++ b/fixtures/test_proxy_init/README.md
@@ -6,7 +6,7 @@ are used in tests.
 The following proxy services are supported:
 
 - mitmproxy
-- squid
+- Squid
 
 As the module only generates the contents of scripts, all proxy
 services are unconditionally represented in the module outputs.
@@ -16,7 +16,7 @@ cloud platform combination for the generated initialization scripts.
 
 ## Example Usage
 
-Invoking the module for squid:
+Invoking the module for Squid:
 
 ```tf
 module "test_proxy_init" {

--- a/fixtures/test_proxy_init/README.md
+++ b/fixtures/test_proxy_init/README.md
@@ -1,8 +1,39 @@
 # Test Proxy Init
 
-This fixture provides initialization logic for proxies used in tests:
+This fixture provides initialization scripts for proxy servers which
+are used in tests.
+
+The following proxy services are supported:
 
 - mitmproxy
 - squid
 
-Ubuntu is the only supported operating system.
+As the module only generates the contents of scripts, all proxy
+services are unconditionally represented in the module outputs.
+
+Ubuntu on GCP is currently the only supported operating system and
+cloud platform combination for the generated initialization scripts.
+
+## Example Usage
+
+Invoking the module for squid:
+
+```tf
+module "test_proxy_init" {
+  source = "github.com/hashicorp/terraform-random-tfe-utility//fixtures/test_proxy_init"
+}
+
+resource "google_compute_instance" "squid" {
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.ubuntu.id
+    }
+  }
+
+  name         = "squid"
+
+  metadata_startup_script = module.test_proxy_init.squid.user_data_script
+
+  # Other required and optional arguments...
+}
+```

--- a/fixtures/test_proxy_init/main.tf
+++ b/fixtures/test_proxy_init/main.tf
@@ -3,8 +3,8 @@ locals {
   mitmproxy_user_data_script_base64_encoded = base64encode(templatefile(
     "${path.module}/templates/mitmproxy.sh.tpl",
     {
-      ca_certificate_secret = tostring(var.mitmproxy_ca_certificate_secret)
-      ca_private_key_secret = tostring(var.mitmproxy_ca_private_key_secret)
+      ca_certificate_secret = var.mitmproxy_ca_certificate_secret == null ? "" : var.mitmproxy_ca_certificate_secret
+      ca_private_key_secret = var.mitmproxy_ca_private_key_secret == null ? "" : var.mitmproxy_ca_private_key_secret
       http_port             = local.mitmproxy_http_port
     }
   ))

--- a/fixtures/test_proxy_init/main.tf
+++ b/fixtures/test_proxy_init/main.tf
@@ -1,1 +1,17 @@
-# coming soon
+locals {
+  mitmproxy_http_port = 8080
+  mitmproxy_user_data_script_base64_encoded = base64encode(templatefile(
+    "${path.module}/templates/mitmproxy.sh.tpl",
+    {
+      ca_certificate_secret = var.mitmproxy_ca_certificate_secret
+      ca_private_key_secret = var.mitmproxy_ca_private_key_secret
+      http_port             = local.mitmproxy_http_port
+    }
+  ))
+
+  squid_http_port = 3128
+  squid_user_data_script_base64_encoded = base64encode(templatefile(
+    "${path.module}/templates/squid.sh.tpl",
+    { http_port = local.squid_http_port }
+  ))
+}

--- a/fixtures/test_proxy_init/main.tf
+++ b/fixtures/test_proxy_init/main.tf
@@ -3,8 +3,8 @@ locals {
   mitmproxy_user_data_script_base64_encoded = base64encode(templatefile(
     "${path.module}/templates/mitmproxy.sh.tpl",
     {
-      ca_certificate_secret = var.mitmproxy_ca_certificate_secret
-      ca_private_key_secret = var.mitmproxy_ca_private_key_secret
+      ca_certificate_secret = tostring(var.mitmproxy_ca_certificate_secret)
+      ca_private_key_secret = tostring(var.mitmproxy_ca_private_key_secret)
       http_port             = local.mitmproxy_http_port
     }
   ))

--- a/fixtures/test_proxy_init/main.tf
+++ b/fixtures/test_proxy_init/main.tf
@@ -1,17 +1,17 @@
 locals {
   mitmproxy_http_port = 8080
-  mitmproxy_user_data_script_base64_encoded = base64encode(templatefile(
+  mitmproxy_user_data_script = templatefile(
     "${path.module}/templates/mitmproxy.sh.tpl",
     {
       ca_certificate_secret = var.mitmproxy_ca_certificate_secret == null ? "" : var.mitmproxy_ca_certificate_secret
       ca_private_key_secret = var.mitmproxy_ca_private_key_secret == null ? "" : var.mitmproxy_ca_private_key_secret
       http_port             = local.mitmproxy_http_port
     }
-  ))
+  )
 
   squid_http_port = 3128
-  squid_user_data_script_base64_encoded = base64encode(templatefile(
+  squid_user_data_script = templatefile(
     "${path.module}/templates/squid.sh.tpl",
     { http_port = local.squid_http_port }
-  ))
+  )
 }

--- a/fixtures/test_proxy_init/outputs.tf
+++ b/fixtures/test_proxy_init/outputs.tf
@@ -1,7 +1,7 @@
 output "mitmproxy" {
   value = {
-    http_port                       = local.mitmproxy_http_port
-    user_data_script_base64_encoded = local.mitmproxy_user_data_script_base64_encoded
+    http_port        = local.mitmproxy_http_port
+    user_data_script = local.mitmproxy_user_data_script
   }
 
   description = "The HTTP port and user data shell script for an mitmproxy installation."
@@ -9,8 +9,8 @@ output "mitmproxy" {
 
 output "squid" {
   value = {
-    http_port                       = local.squid_http_port
-    user_data_script_base64_encoded = local.squid_user_data_script_base64_encoded
+    http_port        = local.squid_http_port
+    user_data_script = local.squid_user_data_script
   }
 
   description = "The HTTP port and user data shell script for a Squid installation."

--- a/fixtures/test_proxy_init/outputs.tf
+++ b/fixtures/test_proxy_init/outputs.tf
@@ -9,7 +9,7 @@ output "mitmproxy" {
 
 output "squid" {
   value = {
-    http_port = local.squid_http_port
+    http_port                       = local.squid_http_port
     user_data_script_base64_encoded = local.squid_user_data_script_base64_encoded
   }
 

--- a/fixtures/test_proxy_init/outputs.tf
+++ b/fixtures/test_proxy_init/outputs.tf
@@ -1,0 +1,17 @@
+output "mitmproxy" {
+  value = {
+    http_port                       = local.mitmproxy_http_port
+    user_data_script_base64_encoded = local.mitmproxy_user_data_script_base64_encoded
+  }
+
+  description = "The HTTP port and user data shell script for an mitmproxy installation."
+}
+
+output "squid" {
+  value = {
+    http_port = local.squid_http_port
+    user_data_script_base64_encoded = local.squid_user_data_script_base64_encoded
+  }
+
+  description = "The HTTP port and user data shell script for a Squid installation."
+}

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -16,10 +16,10 @@ echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /v
 certificate="$confdir/mitmproxy-ca.pem"
 
 gcloud secrets versions access latest --secret="${ca_certificate_secret}" \
-    | base64 --decode --ignore-garbage | tee $certificate
+  | base64 --decode --ignore-garbage | tee $certificate
 
 gcloud secrets versions access latest --secret="${ca_private_key_secret}" \
-    base64 --decode --ignore-garbage | tee --append $certificate
+  | base64 --decode --ignore-garbage | tee --append $certificate
 
 %{ endif ~}
 echo "[$(date +"%FT%T")] Configuring mitmproxy" | tee --append /var/log/ptfe.log

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -8,6 +8,8 @@ echo "[$(date +"%FT%T")] Installing mitmproxy" | tee --append /var/log/ptfe.log
 pushd /tmp
 curl --location --remote-name https://snapshots.mitmproxy.org/6.0.2/mitmproxy-6.0.2-linux.tar.gz
 tar --extract --file ./mitmproxy*.tar.gz -C /usr/local/bin/
+confdir="/etc/mitmproxy"
+mkdir --parents $confdir
 
 echo "[$(date +"%FT%T")] Installing jq" | tee --append /var/log/ptfe.log
 curl --location --output /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
@@ -27,8 +29,6 @@ curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}/versions/
 %{ endif ~}
 
 echo "[$(date +"%FT%T")] Configuring mitmproxy" | tee --append /var/log/ptfe.log
-confdir="/etc/mitmproxy"
-mkdir -p $confdir
 service="/etc/systemd/system/mitmproxy.service"
 touch $service
 chown root:root $service

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -16,10 +16,10 @@ echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /v
 certificate="$confdir/mitmproxy-ca.pem"
 access_token=$(curl http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
   | jq -r .access_token)
-curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}" \
+curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}/versions/latest" \
     --header "Authorization: Bearer $access_token" \
     | jq -r .payload.data | base64 --decode | tee $certificate
-curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}" \
+curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}/versions/latest" \
     --header "Authorization: Bearer $access_token" \
     | jq -r .payload.data | base64 --decode | tee --append $certificate
 

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -22,10 +22,10 @@ access_token=$(curl \
   --header "Metadata-Flavor: Google" \
   http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
   | jq -r .access_token)
-curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}/versions/latest" \
+curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}" \
     --header "Authorization: Bearer $access_token" \
     | jq -r .payload.data | base64 --decode | tee $certificate
-curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}/versions/latest" \
+curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}" \
     --header "Authorization: Bearer $access_token" \
     | jq -r .payload.data | base64 --decode | tee --append $certificate
 %{ endif ~}

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -18,7 +18,9 @@ chmod +x /usr/local/bin/jq
 %{ if ca_certificate_secret != "" && ca_private_key_secret != "" ~}
 echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /var/log/ptfe.log
 certificate="$confdir/mitmproxy-ca.pem"
-access_token=$(curl http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
+access_token=$(curl \
+  --header "Metadata-Flavor: Google" \
+  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
   | jq -r .access_token)
 curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}/versions/latest" \
     --header "Authorization: Bearer $access_token" \

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+echo "[$(date +"%FT%T")] Starting mitmproxy startup script" | tee --append /var/log/ptfe.log
+
+echo "[$(date +"%FT%T")] Installing mitmproxy" | tee --append /var/log/ptfe.log
+curl --location --remote-name https://snapshots.mitmproxy.org/6.0.2/mitmproxy-6.0.2-linux.tar.gz
+tar --extract --file /tmp/mitmproxy*.tar.gz -C /usr/local/bin/
+
+echo "[$(date +"%FT%T")] Installing jq" | tee --append /var/log/ptfe.log
+curl --location --output /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+chmod +x /usr/local/bin/jq
+
+echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /var/log/ptfe.log
+certificate="$confdir/mitmproxy-ca.pem"
+access_token=$(curl http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
+  | jq -r .access_token)
+curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}" \
+    --header "Authorization: Bearer $access_token" \
+    | jq -r .payload.data | base64 --decode | tee $certificate
+curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}" \
+    --header "Authorization: Bearer $access_token" \
+    | jq -r .payload.data | base64 --decode | tee --append $certificate
+
+echo "[$(date +"%FT%T")] Configuring mitmproxy" | tee --append /var/log/ptfe.log
+confdir="/etc/mitmproxy"
+mkdir -p $confdir
+service="/etc/systemd/system/mitmproxy.service"
+touch $service
+chown root:root $service
+chmod 0644 $service
+
+cat <<EOF >$service
+[Unit]
+Description=mitmproxy
+ConditionPathExists=$confdir
+[Service]
+ExecStart=/usr/local/bin/mitmdump --port ${http_port} --set confdir=$confdir
+Restart=always
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "[$(date +"%FT%T")] Starting mitmproxy service" | tee --append /var/log/ptfe.log
+systemctl daemon-reload
+systemctl start mitmproxy
+systemctl enable mitmproxy
+
+echo "[$(date +"%FT%T")] Finished mitmproxy startup script" | tee --append /var/log/ptfe.log

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -5,8 +5,9 @@ set -e -u -o pipefail
 echo "[$(date +"%FT%T")] Starting mitmproxy startup script" | tee --append /var/log/ptfe.log
 
 echo "[$(date +"%FT%T")] Installing mitmproxy" | tee --append /var/log/ptfe.log
+pushd /tmp
 curl --location --remote-name https://snapshots.mitmproxy.org/6.0.2/mitmproxy-6.0.2-linux.tar.gz
-tar --extract --file /tmp/mitmproxy*.tar.gz -C /usr/local/bin/
+tar --extract --file ./mitmproxy*.tar.gz -C /usr/local/bin/
 
 echo "[$(date +"%FT%T")] Installing jq" | tee --append /var/log/ptfe.log
 curl --location --output /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -12,6 +12,7 @@ echo "[$(date +"%FT%T")] Installing jq" | tee --append /var/log/ptfe.log
 curl --location --output /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
 chmod +x /usr/local/bin/jq
 
+%{ if ca_certificate_secret != "" && ca_private_key_secret != "" ~}
 echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /var/log/ptfe.log
 certificate="$confdir/mitmproxy-ca.pem"
 access_token=$(curl http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
@@ -22,6 +23,7 @@ curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}/versions/
 curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}/versions/latest" \
     --header "Authorization: Bearer $access_token" \
     | jq -r .payload.data | base64 --decode | tee --append $certificate
+%{ endif ~}
 
 echo "[$(date +"%FT%T")] Configuring mitmproxy" | tee --append /var/log/ptfe.log
 confdir="/etc/mitmproxy"

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -11,25 +11,17 @@ tar --extract --file ./mitmproxy*.tar.gz -C /usr/local/bin/
 confdir="/etc/mitmproxy"
 mkdir --parents $confdir
 
-echo "[$(date +"%FT%T")] Installing jq" | tee --append /var/log/ptfe.log
-curl --location --output /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-chmod +x /usr/local/bin/jq
-
 %{ if ca_certificate_secret != "" && ca_private_key_secret != "" ~}
 echo "[$(date +"%FT%T")] Deploying certificates for mitmproxy" | tee --append /var/log/ptfe.log
 certificate="$confdir/mitmproxy-ca.pem"
-access_token=$(curl \
-  --header "Metadata-Flavor: Google" \
-  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
-  | jq -r .access_token)
-curl "https://secretmanager.googleapis.com/v1/${ca_certificate_secret}" \
-    --header "Authorization: Bearer $access_token" \
-    | jq -r .payload.data | base64 --decode | tee $certificate
-curl "https://secretmanager.googleapis.com/v1/${ca_private_key_secret}" \
-    --header "Authorization: Bearer $access_token" \
-    | jq -r .payload.data | base64 --decode | tee --append $certificate
-%{ endif ~}
 
+gcloud secrets versions access latest --secret="${ca_certificate_secret}" \
+    | base64 --decode --ignore-garbage | tee $certificate
+
+gcloud secrets versions access latest --secret="${ca_private_key_secret}" \
+    base64 --decode --ignore-garbage | tee --append $certificate
+
+%{ endif ~}
 echo "[$(date +"%FT%T")] Configuring mitmproxy" | tee --append /var/log/ptfe.log
 service="/etc/systemd/system/mitmproxy.service"
 touch $service

--- a/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
+++ b/fixtures/test_proxy_init/templates/mitmproxy.sh.tpl
@@ -33,7 +33,7 @@ cat <<EOF >$service
 Description=mitmproxy
 ConditionPathExists=$confdir
 [Service]
-ExecStart=/usr/local/bin/mitmdump --port ${http_port} --set confdir=$confdir
+ExecStart=/usr/local/bin/mitmdump --listen-port ${http_port} --set confdir=$confdir
 Restart=always
 [Install]
 WantedBy=multi-user.target

--- a/fixtures/test_proxy_init/templates/squid.sh.tpl
+++ b/fixtures/test_proxy_init/templates/squid.sh.tpl
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+echo "[$(date +"%FT%T")] Starting Squid startup script" | tee --append /var/log/ptfe.log
+
+echo "[$(date +"%FT%T")] Installing Squid" | tee --append /var/log/ptfe.log
+apt-get --assume-yes update
+apt-get --assume-yes install squid
+
+echo "[$(date +"%FT%T")] Configuring Squid" | tee --append /var/log/ptfe.log
+cat <<EOF > /etc/squid/squid.conf
+# https://wiki.squid-cache.org/SquidFaq/ConfiguringSquid#Squid-3.5_default_config
+
+http_port ${http_port}
+
+acl localnet src 10.0.0.0/8     # RFC1918 possible internal network
+acl localnet src 172.16.0.0/12  # RFC1918 possible internal network
+acl localnet src 192.168.0.0/16 # RFC1918 possible internal network
+acl localnet src fc00::/7       # RFC 4193 local private network range
+acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+
+acl Safe_ports port 80          # http
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 443         # https
+acl Safe_ports port 70          # gopher
+acl Safe_ports port 210         # wais
+acl Safe_ports port 280         # http-mgmt
+acl Safe_ports port 488         # gss-http
+acl Safe_ports port 591         # filemaker
+acl Safe_ports port 777         # multiling http
+acl Safe_ports port 1025-65535  # unregistered ports
+
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost manager
+http_access deny manager
+
+http_access allow localnet
+http_access allow localhost
+http_access deny all
+
+coredump_dir /squid/var/cache/squid
+
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern .               0       20%     4320
+EOF
+
+echo "[$(date +"%FT%T")] Restarting Squid" | tee --append /var/log/ptfe.log
+systemctl restart squid
+
+echo "[$(date +"%FT%T")] Finished Squid startup script" | tee --append /var/log/ptfe.log

--- a/fixtures/test_proxy_init/variables.tf
+++ b/fixtures/test_proxy_init/variables.tf
@@ -2,7 +2,6 @@ variable "mitmproxy_ca_certificate_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM certificate file for the mitmproxy Certificate Authority.
-  For GCP, this is the name of a secret version.
   EOD
   type        = string
 }
@@ -11,7 +10,6 @@ variable "mitmproxy_ca_private_key_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM private key file for the mitmproxy Certificate Authority.
-  For GCP, this is the name of a secret version.
   EOD
   type        = string
 }

--- a/fixtures/test_proxy_init/variables.tf
+++ b/fixtures/test_proxy_init/variables.tf
@@ -2,6 +2,7 @@ variable "mitmproxy_ca_certificate_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM certificate file for the mitmproxy Certificate Authority.
+  For GCP, this value must be formatted as "projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}".
   EOD
   type        = string
 }
@@ -10,6 +11,7 @@ variable "mitmproxy_ca_private_key_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM private key file for the mitmproxy Certificate Authority.
+  For GCP, this value must be formatted as "projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}".
   EOD
   type        = string
 }

--- a/fixtures/test_proxy_init/variables.tf
+++ b/fixtures/test_proxy_init/variables.tf
@@ -2,7 +2,7 @@ variable "mitmproxy_ca_certificate_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM certificate file for the mitmproxy Certificate Authority.
-  For GCP, this value must be formatted as "projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}".
+  For GCP, the Terraform provider calls this value the secret_id and the GCP UI calls it the name.
   EOD
   type        = string
 }
@@ -11,7 +11,7 @@ variable "mitmproxy_ca_private_key_secret" {
   default     = null
   description = <<-EOD
   The identifier of a secret comprising a Base64 encoded PEM private key file for the mitmproxy Certificate Authority.
-  For GCP, this value must be formatted as "projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}".
+  For GCP, the Terraform provider calls this value the secret_id and the GCP UI calls it the name.
   EOD
   type        = string
 }

--- a/fixtures/test_proxy_init/variables.tf
+++ b/fixtures/test_proxy_init/variables.tf
@@ -1,0 +1,17 @@
+variable "mitmproxy_ca_certificate_secret" {
+  default     = null
+  description = <<-EOD
+  The identifier of a secret comprising a Base64 encoded PEM certificate file for the mitmproxy Certificate Authority.
+  For GCP, this is the name of a secret version.
+  EOD
+  type        = string
+}
+
+variable "mitmproxy_ca_private_key_secret" {
+  default     = null
+  description = <<-EOD
+  The identifier of a secret comprising a Base64 encoded PEM private key file for the mitmproxy Certificate Authority.
+  For GCP, this is the name of a secret version.
+  EOD
+  type        = string
+}

--- a/fixtures/test_proxy_init/versions.tf
+++ b/fixtures/test_proxy_init/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
## Background

This branch adds the test proxy init fixture with initial support for Ubuntu on GCP deployments.

Asana task: https://app.asana.com/0/1181500399442529/1201422598987197/f

## How has this been tested?

Tested here https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/135

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/n6mEMqAuYOQ8l8qcEE/giphy.gif?cid=5a38a5a27mp9agrkhoiau13lbmrt4uysftjgzrddx0l1yswc&rid=giphy.gif&ct=g)
