### PR TITLE
add HCP Vault fixture module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,25 @@
 # Local .terraform directories
+/.terraform/
 **/.terraform/*
 
 # .tfstate files
 *.tfstate
 *.tfstate.*
+
+# .tfvars files
+*.tfvars
+
+# Terraform lock file
+.terraform.lock.hcl
+
+.DS_Store
+*.bk
+
+# Editor files
+.vscode
+
+# TFE license
+*.rli
 
 # Crash log files
 crash.log

--- a/fixtures/test_hcp_vault/main.tf
+++ b/fixtures/test_hcp_vault/main.tf
@@ -1,1 +1,77 @@
-# coming soon
+# Vault AppRole
+# -------------
+resource "hcp_vault_cluster" "test" {
+  cluster_id      = var.hcp_vault_cluster_id
+  hvn_id          = var.hcp_vault_cluster_hvn_id
+  public_endpoint = var.hcp_vault_cluster_public_endpoint
+  tier            = var.hcp_vault_cluster_tier
+}
+
+resource "hcp_vault_cluster_admin_token" "test" {
+  cluster_id = hcp_vault_cluster.test.cluster_id
+}
+
+# Vault Policy
+# -------------
+resource "vault_policy" "ptfe" {
+  name = var.vault_policy_name
+
+  policy = <<EOT
+    path "auth/approle/login" {
+      capabilities = ["create", "read"]
+    }
+    path "sys/renew/*" {
+      policy = "write"
+    }
+    path "auth/token/renew/*" {
+      policy = "write"
+    }
+    path "transit/encrypt/atlas_*" {
+      capabilities = ["create", "update"]
+    }
+    path "transit/decrypt/atlas_*" {
+      capabilities = ["update"]
+    }
+    path "transit/encrypt/archivist_*" {
+      capabilities = ["create", "update"]
+    }
+    # For decrypting datakey ciphertexts.
+    path "transit/decrypt/archivist_*" {
+      capabilities = ["update"]
+    }
+    # To upsert the transit key used for datakey generation.
+    path "transit/keys/archivist_*" {
+      capabilities = ["create", "update"]
+    }
+    # For performing key derivation.
+    path "transit/datakey/plaintext/archivist_*" {
+      capabilities = ["update"]
+    }
+    # For health checks to read the mount table.
+    path "sys/mounts" {
+      capabilities = ["read"]
+    }
+EOT
+}
+
+# Vault AppRole
+# -------------
+resource "vault_auth_backend" "approle" {
+  type = "approle"
+}
+
+resource "vault_approle_auth_backend_role" "approle" {
+  backend        = vault_auth_backend.approle.path
+  role_name      = var.vault_role_name
+  token_policies = [vault_policy.ptfe.name]
+}
+
+resource "vault_approle_auth_backend_role_secret_id" "approle" {
+  backend   = vault_auth_backend.approle.path
+  role_name = vault_approle_auth_backend_role.approle.role_name
+}
+
+resource "vault_mount" "transit" {
+  path = "transit"
+  type = "transit"
+}

--- a/fixtures/test_hcp_vault/outputs.tf
+++ b/fixtures/test_hcp_vault/outputs.tf
@@ -1,0 +1,14 @@
+output "url" {
+  value       = hcp_vault_cluster.test.vault_public_endpoint_url
+  description = "The public endpoint of the HCP Vault Cluster."
+}
+
+output "app_role_id" {
+  value       = vault_approle_auth_backend_role.approle.role_id
+  description = "The role ID of the Vault's app role."
+}
+
+output "app_role_secret_id" {
+  value       = vault_approle_auth_backend_role_secret_id.approle.secret_id
+  description = "The secret ID of the Vault's app role."
+}

--- a/fixtures/test_hcp_vault/provider.tf
+++ b/fixtures/test_hcp_vault/provider.tf
@@ -1,0 +1,5 @@
+# Credentials will be set via the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET
+provider "vault" {
+  address = hcp_vault_cluster.test.vault_public_endpoint_url
+  token   = hcp_vault_cluster_admin_token.test.token
+}

--- a/fixtures/test_hcp_vault/variables.tf
+++ b/fixtures/test_hcp_vault/variables.tf
@@ -1,0 +1,38 @@
+variable "hcp_vault_cluster_id" {
+  type        = string
+  description = "The ID of the HCP Vault cluster."
+}
+
+variable "hcp_vault_cluster_hvn_id" {
+  type        = string
+  description = "The ID of the HVN to which this HCP Vault cluster is associated."
+}
+
+variable "hcp_vault_cluster_public_endpoint" {
+  type        = bool
+  description = "Denotes that the cluster has a public endpoint."
+}
+
+variable "hcp_vault_cluster_tier" {
+  type        = string
+  description = "Tier of the HCP Vault cluster. Must be standard_medium or standard_large."
+
+  validation {
+    condition = (
+      var.hcp_vault_cluster_tier == "standard_medium" ||
+      var.hcp_vault_cluster_tier == "standard_large"
+    )
+
+    error_message = "The hcp_vault_cluster_tier must be 'standard_medium' or 'standard_large'."
+  }
+}
+
+variable "vault_role_name" {
+  type        = string
+  description = "The name of the vault role."
+}
+
+variable "vault_policy_name" {
+  type        = string
+  description = "The name of the vault policy."
+}

--- a/fixtures/test_hcp_vault/versions.tf
+++ b/fixtures/test_hcp_vault/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "0.18.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.1"
+    }
+  }
+}


### PR DESCRIPTION
## Background

This branch adds a fixture module to create an HCP Vault.

Asana: https://app.asana.com/0/1181500399442529/1201752311630251/f

Merge order:

- [ ] [terraform-random-tfe-utility](https://github.com/hashicorp/terraform-random-tfe-utility/pull/8)
- [ ] [terraform-aws-terraform-enterprise](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/224)
- [ ] [ptfe-replicated](https://github.com/hashicorp/ptfe-replicated/pull/948)

## How has this been tested?

I pointed the source of this branch's module to [this branch in the AWS `standalone-vault` test](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/224) and ran it in a CircleCi run on [this branch](https://github.com/hashicorp/ptfe-replicated/pull/948) of ptfe-replicated.
✅  `scenario_aws_standalone_vault` [test](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2846/workflows/993eb1ec-e93b-48ec-8852-0ccab1b15f1e/jobs/19919)

## This PR makes me feel

![first step](https://media.giphy.com/media/ftMALI3OsvHg6BOZ59/giphy.gif)
