### PR TITLE
adding airgap functionality

### DIFF
--- a/modules/settings/replicated_config.tf
+++ b/modules/settings/replicated_config.tf
@@ -10,13 +10,13 @@ locals {
     DaemonAuthenticationPassword      = random_string.password.result
     ImportSettingsFrom                = "/etc/ptfe-settings.json"
     LicenseFileLocation               = var.tfe_license_file_location
-    LicenseBootstrapAirgapPackagePath = var.is_airgap != null ? var.is_airgap ? var.tfe_license_bootstrap_airgap_package_path : null : null
+    LicenseBootstrapAirgapPackagePath = var.tfe_license_bootstrap_airgap_package_path
     LicenseBootstrapChannelID         = var.tfe_license_bootstrap_channel_id
     LogLevel                          = var.log_level
     TlsBootstrapHostname              = var.hostname
     TlsBootstrapCert                  = var.tls_bootstrap_cert_pathname
     TlsBootstrapKey                   = var.tls_bootstrap_key_pathname
     TlsBootstrapType                  = var.tls_bootstrap_cert_pathname != null ? "server-path" : "self-signed"
-    ReleaseSequence                   = var.is_airgap != null ? var.is_airgap ? null : var.release_sequence : null
+    ReleaseSequence                   = var.tfe_license_bootstrap_airgap_package_path != null ? null : var.release_sequence
   }
 }

--- a/modules/settings/replicated_config.tf
+++ b/modules/settings/replicated_config.tf
@@ -10,13 +10,13 @@ locals {
     DaemonAuthenticationPassword      = random_string.password.result
     ImportSettingsFrom                = "/etc/ptfe-settings.json"
     LicenseFileLocation               = var.tfe_license_file_location
-    LicenseBootstrapAirgapPackagePath = var.tfe_license_bootstrap_airgap_package_path
+    LicenseBootstrapAirgapPackagePath = var.is_airgap != null ? var.is_airgap ? var.tfe_license_bootstrap_airgap_package_path : null : null
     LicenseBootstrapChannelID         = var.tfe_license_bootstrap_channel_id
     LogLevel                          = var.log_level
     TlsBootstrapHostname              = var.hostname
     TlsBootstrapCert                  = var.tls_bootstrap_cert_pathname
     TlsBootstrapKey                   = var.tls_bootstrap_key_pathname
     TlsBootstrapType                  = var.tls_bootstrap_cert_pathname != null ? "server-path" : "self-signed"
-    ReleaseSequence                   = var.release_sequence
+    ReleaseSequence                   = var.is_airgap != null ? var.is_airgap ? null : var.release_sequence : null
   }
 }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -273,12 +273,6 @@ variable "log_level" {
   }
 }
 
-variable "is_airgap" {
-  default     = null
-  type        = bool
-  description = "(Optional) A boolean to determine if this is an air-gapped installation of TFE."
-}
-
 variable "tfe_license_bootstrap_airgap_package_path" {
   default     = null
   type        = string

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -273,6 +273,12 @@ variable "log_level" {
   }
 }
 
+variable "is_airgap" {
+  default     = null
+  type        = bool
+  description = "(Optional) A boolean to determine if this is an air-gapped installation of TFE."
+}
+
 variable "tfe_license_bootstrap_airgap_package_path" {
   default     = null
   type        = string

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -13,7 +13,7 @@ locals {
       settings                      = base64encode(jsonencode(var.tfe_configuration))
       tls_bootstrap_cert_pathname   = var.replicated_configuration.TlsBootstrapCert
       tls_bootstrap_key_pathname    = var.replicated_configuration.TlsBootstrapKey
-      airgap_url                    = var.airgap_url != null ? var.airgap_url : null
+      airgap_url                    = var.airgap_url
       airgap_pathname               = var.airgap_url != null ? var.replicated_configuration.LicenseBootstrapAirgapPackagePath : null
       bootstrap_airgap_installation = var.airgap_url != null ? var.bootstrap_airgap_installation != null ? var.bootstrap_airgap_installation ? true : !var.bootstrap_airgap_installation : false : false
 

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -1,18 +1,28 @@
 locals {
+
+  bootstrap_airgap = var.airgap_url != null ? var.bootstrap_airgap_installation != null ? var.bootstrap_airgap_installation ? true : !var.bootstrap_airgap_installation : false : false
+
   # Build TFE user data / custom data / cloud init
   tfe_user_data = templatefile(
     "${path.module}/templates/tfe.sh.tpl",
     {
       # Configuration data
-      active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
-      replicated                  = base64encode(jsonencode(var.replicated_configuration))
-      settings                    = base64encode(jsonencode(var.tfe_configuration))
-      tls_bootstrap_cert_pathname = var.replicated_configuration.TlsBootstrapCert
-      tls_bootstrap_key_pathname  = var.replicated_configuration.TlsBootstrapKey
+      cloud                         = var.cloud
+      active_active                 = var.tfe_configuration.enable_active_active.value == "1" ? true : false
+      replicated                    = base64encode(jsonencode(var.replicated_configuration))
+      settings                      = base64encode(jsonencode(var.tfe_configuration))
+      tls_bootstrap_cert_pathname   = var.replicated_configuration.TlsBootstrapCert
+      tls_bootstrap_key_pathname    = var.replicated_configuration.TlsBootstrapKey
+      airgap_url                    = var.airgap_url != null ? var.airgap_url : null
+      airgap_pathname               = var.airgap_url != null ? var.replicated_configuration.LicenseBootstrapAirgapPackagePath : null
+      bootstrap_airgap_installation = var.airgap_url != null ? var.bootstrap_airgap_installation != null ? var.bootstrap_airgap_installation ? true : !var.bootstrap_airgap_installation : false : false
 
       # Secrets
       ca_certificate_secret     = var.ca_certificate_secret
       certificate_secret        = var.certificate_secret
+      ca_certificate_data_b64   = !local.bootstrap_airgap ? var.ca_certificate_data_b64 != null ? var.ca_certificate_data_b64 : null : null
+      certificate_data_b64      = !local.bootstrap_airgap ? var.certificate_data_b64 != null ? var.certificate_data_b64 : null : null
+      key_data_b64              = !local.bootstrap_airgap ? var.key_data_b64 != null ? var.key_data_b64 : null : null
       key_secret                = var.key_secret
       tfe_license_file_location = var.replicated_configuration.LicenseFileLocation
       tfe_license_secret        = var.tfe_license_secret

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -15,7 +15,7 @@ locals {
       tls_bootstrap_cert_pathname   = var.replicated_configuration.TlsBootstrapCert
       tls_bootstrap_key_pathname    = var.replicated_configuration.TlsBootstrapKey
       airgap_url                    = var.airgap_url
-      airgap_pathname               = var.replicated_configuration.LicenseBootstrapAirgapPackagePath
+      airgap_pathname               = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
 
       # Secrets
       ca_certificate_secret     = var.ca_certificate_secret

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -1,7 +1,5 @@
 locals {
 
-  bootstrap_airgap = var.airgap_url != null ? var.bootstrap_airgap_installation != null ? var.bootstrap_airgap_installation ? true : !var.bootstrap_airgap_installation : false : false
-
   # Build TFE user data / custom data / cloud init
   tfe_user_data = templatefile(
     "${path.module}/templates/tfe.sh.tpl",
@@ -17,15 +15,11 @@ locals {
       tls_bootstrap_cert_pathname   = var.replicated_configuration.TlsBootstrapCert
       tls_bootstrap_key_pathname    = var.replicated_configuration.TlsBootstrapKey
       airgap_url                    = var.airgap_url
-      airgap_pathname               = var.airgap_url != null ? var.replicated_configuration.LicenseBootstrapAirgapPackagePath : null
-      bootstrap_airgap_installation = var.airgap_url != null ? var.bootstrap_airgap_installation != null ? var.bootstrap_airgap_installation ? true : !var.bootstrap_airgap_installation : false : false
+      airgap_pathname               = var.replicated_configuration.LicenseBootstrapAirgapPackagePath
 
       # Secrets
       ca_certificate_secret     = var.ca_certificate_secret
       certificate_secret        = var.certificate_secret
-      ca_certificate_data_b64   = !local.bootstrap_airgap ? var.ca_certificate_data_b64 != null ? var.ca_certificate_data_b64 : null : null
-      certificate_data_b64      = !local.bootstrap_airgap ? var.certificate_data_b64 != null ? var.certificate_data_b64 : null : null
-      key_data_b64              = !local.bootstrap_airgap ? var.key_data_b64 != null ? var.key_data_b64 : null : null
       key_secret                = var.key_secret
       tfe_license_file_location = var.replicated_configuration.LicenseFileLocation
       tfe_license_secret        = var.tfe_license_secret

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -6,6 +6,9 @@ locals {
   tfe_user_data = templatefile(
     "${path.module}/templates/tfe.sh.tpl",
     {
+      # Functions
+      get_base64_secrets = data.template_file.get_base64_secrets.rendered
+
       # Configuration data
       cloud                         = var.cloud
       active_active                 = var.tfe_configuration.enable_active_active.value == "1" ? true : false
@@ -33,4 +36,12 @@ locals {
       no_proxy   = var.tfe_configuration.extra_no_proxy.value
     }
   )
+}
+
+data "template_file" "get_base64_secrets" {
+  template = file("${path.module}/templates/get_base64_secrets.func")
+
+  vars = {
+    cloud = var.cloud
+  }
 }

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -4,9 +4,7 @@ function get_base64_secrets {
   # OS: Agnostic
   # Description: Pull the Base 64 encoded secrets from Azure Key Vault
 
-  echo "[$(date +"%FT%T")] [Terraform Enterprise] Obtain access token for Azure Key Vault" | tee -a /var/log/ptfe.log
-  access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-  echo "[$(date +"%FT%T")] [Terraform Enterprise] Pull secret from Key Vault" | tee -a /var/log/ptfe.log
-  data_b64=$(curl --noproxy '*' $secret_id?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
+  access_token=$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+  curl -s --noproxy '*' $secret_id?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -1,0 +1,12 @@
+%{ if cloud == "azurerm" ~}
+function get_base64_secrets {
+  local secret_id=$1
+  # OS: Agnostic
+  # Description: Pull the Base 64 encoded secrets from Azure Key Vault
+
+  echo "[$(date +"%FT%T")] [Terraform Enterprise] Obtain access token for Azure Key Vault" | tee -a /var/log/ptfe.log
+  access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+  echo "[$(date +"%FT%T")] [Terraform Enterprise] Pull secret from Key Vault" | tee -a /var/log/ptfe.log
+  data_b64=$(curl --noproxy '*' $secret_id?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -232,7 +232,7 @@ then
 fi
 %{ endif ~}
 
-%{ if bootstrap_airgap_installation ~}
+%{ if bootstrap_airgap_installation && airgap_url != null ~}
 bootstrap_airgap
 %{ endif ~}
 

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -146,9 +146,12 @@ echo $license | base64 -d > ${tfe_license_file_location}
 %{ endif ~}
 
 # -----------------------------------------------------------------------------
-# Bootstrap airgapped environment with prerequisites (for dev/test environments)
+# Download Replicated
 # -----------------------------------------------------------------------------
+replicated_directory="/etc/replicated"
+
 %{ if airgap_url != null && airgap_pathname != null ~}
+# Bootstrap airgapped environment with prerequisites (for dev/test environments)
 echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
 
 if [[ $DISTRO_NAME == *"Red Hat"* ]]
@@ -174,7 +177,6 @@ apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
 apt-get --assume-yes autoremove
 fi
 
-replicated_directory="/etc/replicated"
 replicated_filename="replicated.tar.gz"
 replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
 replicated_pathname="$replicated_directory/$replicated_filename"
@@ -193,7 +195,6 @@ curl --create-dirs --output "${airgap_pathname}" "${airgap_url}"
 # -----------------------------------------------------------------------------
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathname
 instance_ip=$(hostname -i)
-replicated_directory="/tmp/replicated"
 install_pathname="$replicated_directory/install.sh"
 
 %{ if airgap_pathname == null ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -2,238 +2,234 @@
 
 set -e -u -o pipefail
 
-install_jq() {
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a /var/log/ptfe.log
+${get_base64_secrets}
+log_pathname="$log_pathname"
+tfe_settings_file="ptfe-settings.json"
+tfe_settings_path="/etc/$tfe_settings_file"
 
-	sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-	sudo chmod +x /bin/jq
-}
-
-create_tfe_config() {
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Create configuration files" | tee -a /var/log/ptfe.log
-
-	sudo echo "${settings}" | sudo base64 -d > /etc/ptfe-settings.json
-	echo "${replicated}" | base64 -d > /etc/replicated.conf
-}
-
-proxy_config() {
-	%{ if proxy_ip != null ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a /var/log/ptfe.log
-
-	proxy_ip="${proxy_ip}"
-	proxy_port="${proxy_port}"
-	/bin/cat <<EOF >>/etc/environment
-http_proxy="${proxy_ip}:${proxy_port}"
-https_proxy="${proxy_ip}:${proxy_port}"
-no_proxy="${no_proxy}"
-EOF
-
-	/bin/cat <<EOF >/etc/profile.d/proxy.sh
-http_proxy="${proxy_ip}:${proxy_port}"
-https_proxy="${proxy_ip}:${proxy_port}"
-no_proxy="${no_proxy}"
-EOF
-
-	export http_proxy="${proxy_ip}:${proxy_port}"
-	export https_proxy="${proxy_ip}:${proxy_port}"
-	export no_proxy="${no_proxy}"
-	%{ else ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping proxy configuration" | tee -a /var/log/ptfe.log
-	%{ endif ~}
-}
-
-certificate_config() {
-	%{ if certificate_secret != null ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a /var/log/ptfe.log
-		%{ if cloud == "azurerm" && bootstrap_airgap_installation || airgap_url == null ~}
-		# Obtain access token for Azure Key Vault
-		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-		certificate_data_b64=$(curl --noproxy '*' ${certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-		%{ endif ~}
-
-	mkdir -p $(dirname ${tls_bootstrap_cert_pathname})
-	echo $certificate_data_b64 | base64 --decode > ${tls_bootstrap_cert_pathname}
-
-	%{ else ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapCert configuration" | tee -a /var/log/ptfe.log
-
-	%{ endif ~}
-	%{ if key_secret != null ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapKey" | tee -a /var/log/ptfe.log
-		%{ if cloud == "azurerm" && bootstrap_airgap_installation || airgap_url == null ~}
-		# Obtain access token for Azure Key Vault
-		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-		key_data_b64=$(curl --noproxy '*' ${key_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-		%{ endif ~}
-
-	mkdir -p $(dirname ${tls_bootstrap_key_pathname})
-	echo $key_data_b64 | base64 --decode > ${tls_bootstrap_key_pathname}
-	chmod 0600 ${tls_bootstrap_key_pathname}
-	%{ else ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapKey configuration" | tee -a /var/log/ptfe.log
-	%{ endif ~}
-}
-
-ca_config() {
-	%{ if ca_certificate_secret != null ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure CA cert" | tee -a /var/log/ptfe.log
-		%{ if cloud == "azurerm" && bootstrap_airgap_installation || airgap_url == null ~}
-		# Obtain access token for Azure Key Vault
-		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-		ca_certificate_data_b64=$(curl --noproxy '*' ${ca_certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-		%{ endif ~}
-
-	ca_certificate_directory="/dev/null"
-	if [[ $DISTRO_NAME == *"Red Hat"* ]]
-	then
-		ca_certificate_directory=/usr/share/pki/ca-trust-source/anchors
-	else
-		ca_certificate_directory=/usr/local/share/ca-certificates/extra
-	fi
-
-	mkdir -p $ca_certificate_directory
-	echo $ca_certificate_data_b64 | base64 --decode > $ca_certificate_directory/tfe-ca-certificate.crt
-
-	if [[ $DISTRO_NAME == *"Red Hat"* ]]
-	then
-		update-ca-trust
-	else
-		update-ca-certificates
-	fi
-
-	jq ". + { ca_certs: { value: \"$(echo $certificate_data_b64 | base64 --decode)\" } }" -- /etc/ptfe-settings.json > ptfe-settings.json.updated
-	cp ./ptfe-settings.json.updated /etc/ptfe-settings.json
-	%{ else ~}
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping CA certificate configuration" | tee -a /var/log/ptfe.log
-	%{ endif ~}
-}
-
-resize_lv() {
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Resize RHEL logical volume" | tee -a /var/log/ptfe.log
-
-	# Because Microsoft is publishing only LVM-partitioned images, it is necessary to partition it to the specs that TFE requires.
-	# First, extend the partition to fill available space
-	growpart /dev/disk/azure/root 4
-	# Resize the physical volume
-	pvresize /dev/disk/azure/root-part4
-	# Then resize the logical volumes to meet TFE specs
-	lvresize -r -L 10G /dev/mapper/rootvg-rootlv
-	lvresize -r -L 40G /dev/mapper/rootvg-varlv
-}
-
-retrieve_tfe_license() {
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Retrieve TFE license" | tee -a /var/log/ptfe.log
-
-	# Obtain access token for Azure Key Vault
-	access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-	license=$(curl --noproxy '*' ${tfe_license_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-	echo $license | base64 -d > ${tfe_license_file_location}
-}
-
-bootstrap_airgap() {
-	log_pathname="/var/log/ptfe.log"
-	echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
-
-	if [[ $DISTRO_NAME == *"Red Hat"* ]]
-	then
-	yum install --assumeyes yum-utils
-	yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
-	yum install --assumeyes docker-ce docker-ce-cli containerd.io
-	else
-	apt-get --assume-yes update
-	apt-get --assume-yes install \
-		ca-certificates \
-		curl \
-		gnupg \
-		lsb-release
-	curl --fail --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg \
-		| gpg --dearmor --output /usr/share/keyrings/docker-archive-keyring.gpg
-	echo \
-		"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
-		https://download.docker.com/linux/ubuntu $(lsb_release --codename --short) stable" \
-		| sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-	apt-get --assume-yes update
-	apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
-	apt-get --assume-yes autoremove
-	fi
-
-	replicated_directory="/tmp/replicated"
-	replicated_filename="replicated.tar.gz"
-	replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
-	replicated_pathname="$replicated_directory/$replicated_filename"
-	echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_pathname'" | tee -a $log_pathname
-	curl --create-dirs --output "$replicated_pathname" "$replicated_url"
-	echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" | tee -a $log_pathname
-	tar --directory "$replicated_directory" --extract --file "$replicated_pathname"
-
-	echo "[Terraform Enterprise] Copying airgap package '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
-	curl --create-dirs --output "${airgap_pathname}" "${airgap_url}"
-}
-
-install_tfe() {
-	log_pathname="/var/log/ptfe.log"
-	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathname
-
-	instance_ip=$(hostname -i)
-    replicated_directory="/tmp/replicated"
-    install_pathname="$replicated_directory/install.sh"
-    curl -o $install_pathname https://get.replicated.com/docker/terraformenterprise/active-active
-	chmod +x $install_pathname
-    cd $replicated_directory
-
-	$install_pathname \
-		bypass-firewalld-warning \
-		%{ if proxy_ip != null ~}
-		http-proxy="${proxy_ip}:${proxy_port}" \
-		additional-no-proxy="${no_proxy}" \
-		%{ else ~}
-		no-proxy \
-		%{ endif ~}
-		%{if active_active ~}
-		disable-replicated-ui \
-		%{ endif ~}
-		private-address=$instance_ip \
-		public-address=$instance_ip \
-		%{ if airgap_url != null ~}
-		airgap \
-		%{ endif ~}
-		| tee -a $log_pathname
-
-	if [[ $DISTRO_NAME == *"Red Hat"* ]]
-	then
-		echo "[$(date +"%FT%T")] [Terraform Enterprise] Disable SELinux (temporary)" | tee -a $log_pathname
-		setenforce 0
-		echo "[$(date +"%FT%T")] [Terraform Enterprise] Add docker0 to firewalld" | tee -a $log_pathname
-		firewall-cmd --permanent --zone=trusted --change-interface=docker0
-		firewall-cmd --reload
-		echo "[$(date +"%FT%T")] [Terraform Enterprise] Enable SELinux" | tee -a $log_pathname
-		setenforce 1
-	fi
-}
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Determine distribution" | tee -a /var/log/ptfe.log
+################################################################################
+# Determine distibution
+################################################################################
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Determine distribution" | tee -a $log_pathname
 DISTRO_NAME=$(grep "^NAME=" /etc/os-release | cut -d"\"" -f2)
 
+################################################################################
+# Install jq (if not an airgapped environment)
+################################################################################
 %{ if bootstrap_airgap_installation || airgap_url == null ~}
-install_jq
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
+
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo chmod +x /bin/jq
 %{ endif ~}
 
-create_tfe_config
-proxy_config
 
-%{ if bootstrap_airgap_installation || airgap_url == null ~}
-certificate_config
-ca_config
-retrieve_tfe_license
+################################################################################
+# Create TFE & Replicated Settings Files
+################################################################################
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Create configuration files" | tee -a $log_pathname
+sudo echo "${settings}" | sudo base64 -d > $tfe_settings_path
+echo "${replicated}" | base64 -d > /etc/replicated.conf
+
+################################################################################
+# Configure the proxy (if applicable)
+################################################################################
+%{ if proxy_ip != null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname
+
+proxy_ip="${proxy_ip}"
+proxy_port="${proxy_port}"
+/bin/cat <<EOF >>/etc/environment
+http_proxy="${proxy_ip}:${proxy_port}"
+https_proxy="${proxy_ip}:${proxy_port}"
+no_proxy="${no_proxy}"
+EOF
+
+/bin/cat <<EOF >/etc/profile.d/proxy.sh
+http_proxy="${proxy_ip}:${proxy_port}"
+https_proxy="${proxy_ip}:${proxy_port}"
+no_proxy="${no_proxy}"
+EOF
+
+export http_proxy="${proxy_ip}:${proxy_port}"
+export https_proxy="${proxy_ip}:${proxy_port}"
+export no_proxy="${no_proxy}"
+%{ else ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping proxy configuration" | tee -a $log_pathname
+%{ endif ~}
+
+################################################################################
+# Configure TLS (if not an airgapped environment)
+################################################################################
+%{ if (bootstrap_airgap_installation || airgap_url == null) && certificate_secret != null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a $log_pathname
+certificate_data_b64=$(get_base64_secrets ${certificate_secret.id})
+%{ endif ~}
+
+%{ if certificate_data_b64 != null ~}
+mkdir -p $(dirname ${tls_bootstrap_cert_pathname})
+echo $certificate_data_b64 | base64 --decode > ${tls_bootstrap_cert_pathname}
+%{ else ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapCert configuration" | tee -a $log_pathname
+%{ endif ~}
+
+%{ if (bootstrap_airgap_installation || airgap_url == null) && key_secret != null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapKey" | tee -a $log_pathname
+key_data_b64=$(get_base64_secrets ${key_secret.id})
+%{ endif ~}
+
+%{ if key_data_b64 != null ~}
+mkdir -p $(dirname ${tls_bootstrap_key_pathname})
+echo $key_data_b64 | base64 --decode > ${tls_bootstrap_key_pathname}
+chmod 0600 ${tls_bootstrap_key_pathname}
+%{ else ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapKey configuration" | tee -a $log_pathname
+%{ endif ~}
+
+################################################################################
+# Configure CA Certificate (if not an airgapped environment)
+################################################################################
+%{ if (bootstrap_airgap_installation || airgap_url == null) && ca_certificate_secret != null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure CA cert" | tee -a $log_pathname
+ca_certificate_data_b64=$(get_base64_secrets ${ca_certificate_secret.id})
+%{ endif ~}
+
+%{ if ca_certificate_data_b64 != null ~}
+ca_certificate_directory="/dev/null"
 
 if [[ $DISTRO_NAME == *"Red Hat"* ]]
 then
-	resize_lv
+	ca_certificate_directory=/usr/share/pki/ca-trust-source/anchors
+else
+	ca_certificate_directory=/usr/local/share/ca-certificates/extra
+fi
+
+mkdir -p $ca_certificate_directory
+echo $ca_certificate_data_b64 | base64 --decode > $ca_certificate_directory/tfe-ca-certificate.crt
+
+if [[ $DISTRO_NAME == *"Red Hat"* ]]
+then
+	update-ca-trust
+else
+	update-ca-certificates
+fi
+
+jq ". + { ca_certs: { value: \"$(echo $certificate_data_b64 | base64 --decode)\" } }" -- $tfe_settings_path > $tfe_settings_file.updated
+cp ./$tfe_settings_file.updated $tfe_settings_path
+%{ else ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping CA certificate configuration" | tee -a $log_pathname
+%{ endif ~}
+
+################################################################################
+# Resize RHEL logical volume (if Azure environment)
+################################################################################
+%{ if cloud == "azurerm" ~}
+if [[ $DISTRO_NAME == *"Red Hat"* ]]
+then
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Resize RHEL logical volume" | tee -a $log_pathname
+
+# Because Microsoft is publishing only LVM-partitioned images, it is necessary to partition it to the specs that TFE requires.
+# First, extend the partition to fill available space
+growpart /dev/disk/azure/root 4
+# Resize the physical volume
+pvresize /dev/disk/azure/root-part4
+# Then resize the logical volumes to meet TFE specs
+lvresize -r -L 10G /dev/mapper/rootvg-rootlv
+lvresize -r -L 40G /dev/mapper/rootvg-varlv
 fi
 %{ endif ~}
 
-%{ if bootstrap_airgap_installation && airgap_url != null ~}
-bootstrap_airgap
+################################################################################
+# Retrieve TFE license (if not an airgapped environment)
+################################################################################
+%{ if (bootstrap_airgap_installation || airgap_url == null) && tfe_license_secret != null ~}
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Retrieve TFE license" | tee -a $log_pathname
+license=$(get_base64_secrets ${tfe_license_secret.id})
+echo $license | base64 -d > ${tfe_license_file_location}
 %{ endif ~}
 
-install_tfe
+################################################################################
+# Bootstrap airgapped environment with prerequisites (for dev/test environments)
+################################################################################
+%{ if bootstrap_airgap_installation && airgap_url != null ~}
+echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
+
+if [[ $DISTRO_NAME == *"Red Hat"* ]]
+then
+yum install --assumeyes yum-utils
+yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+yum install --assumeyes docker-ce docker-ce-cli containerd.io
+else
+apt-get --assume-yes update
+apt-get --assume-yes install \
+	ca-certificates \
+	curl \
+	gnupg \
+	lsb-release
+curl --fail --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg \
+	| gpg --dearmor --output /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+	"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+	https://download.docker.com/linux/ubuntu $(lsb_release --codename --short) stable" \
+	| sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get --assume-yes update
+apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
+apt-get --assume-yes autoremove
+fi
+
+replicated_directory="/tmp/replicated"
+replicated_filename="replicated.tar.gz"
+replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
+replicated_pathname="$replicated_directory/$replicated_filename"
+
+echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_pathname'" | tee -a $log_pathname
+curl --create-dirs --output "$replicated_pathname" "$replicated_url"
+echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" | tee -a $log_pathname
+tar --directory "$replicated_directory" --extract --file "$replicated_pathname"
+
+echo "[Terraform Enterprise] Copying airgap package '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
+curl --create-dirs --output "${airgap_pathname}" "${airgap_url}"
+%{ endif ~}
+
+################################################################################
+# Install Terraform Enterprise
+################################################################################
+echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathname
+instance_ip=$(hostname -i)
+replicated_directory="/tmp/replicated"
+install_pathname="$replicated_directory/install.sh"
+curl -o $install_pathname https://get.replicated.com/docker/terraformenterprise/active-active
+chmod +x $install_pathname
+cd $replicated_directory
+
+$install_pathname \
+	bypass-firewalld-warning \
+	%{ if proxy_ip != null ~}
+	http-proxy="${proxy_ip}:${proxy_port}" \
+	additional-no-proxy="${no_proxy}" \
+	%{ else ~}
+	no-proxy \
+	%{ endif ~}
+	%{if active_active ~}
+	disable-replicated-ui \
+	%{ endif ~}
+	private-address=$instance_ip \
+	public-address=$instance_ip \
+	%{ if airgap_url != null ~}
+	airgap \
+	%{ endif ~}
+	| tee -a $log_pathname
+
+################################################################################
+# Add docker0 to firewalld (for Red Hat instances only)
+################################################################################
+if [[ $DISTRO_NAME == *"Red Hat"* ]]
+then
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Disable SELinux (temporary)" | tee -a $log_pathname
+	setenforce 0
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Add docker0 to firewalld" | tee -a $log_pathname
+	firewall-cmd --permanent --zone=trusted --change-interface=docker0
+	firewall-cmd --reload
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Enable SELinux" | tee -a $log_pathname
+	setenforce 1
+fi

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -61,7 +61,7 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping proxy configuration" | 
 # -----------------------------------------------------------------------------
 # Configure TLS (if not an airgapped environment)
 # -----------------------------------------------------------------------------
-%{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) && certificate_secret != null ~}
+%{ if certificate_secret != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a $log_pathname
 certificate_data_b64=$(get_base64_secrets ${certificate_secret.id})
 mkdir -p $(dirname ${tls_bootstrap_cert_pathname})
@@ -70,7 +70,7 @@ echo $certificate_data_b64 | base64 --decode > ${tls_bootstrap_cert_pathname}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapCert configuration" | tee -a $log_pathname
 %{ endif ~}
 
-%{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) && key_secret != null ~}
+%{ if key_secret != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapKey" | tee -a $log_pathname
 key_data_b64=$(get_base64_secrets ${key_secret.id})
 mkdir -p $(dirname ${tls_bootstrap_key_pathname})
@@ -94,7 +94,7 @@ else
 fi
 ca_cert_filepath="$ca_certificate_directory/tfe-ca-certificate.crt"
 
-%{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) && ca_certificate_secret != null ~}
+%{ if ca_certificate_secret != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure CA cert" | tee -a $log_pathname
 ca_certificate_data_b64=$(get_base64_secrets ${ca_certificate_secret.id})
 
@@ -139,7 +139,7 @@ fi
 # -----------------------------------------------------------------------------
 # Retrieve TFE license (if not an airgapped environment)
 # -----------------------------------------------------------------------------
-%{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) && tfe_license_secret != null ~}
+%{ if tfe_license_secret != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Retrieve TFE license" | tee -a $log_pathname
 license=$(get_base64_secrets ${tfe_license_secret.id})
 echo $license | base64 -d > ${tfe_license_file_location}
@@ -174,7 +174,7 @@ apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
 apt-get --assume-yes autoremove
 fi
 
-replicated_directory="/tmp/replicated"
+replicated_directory="/etc/replicated"
 replicated_filename="replicated.tar.gz"
 replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
 replicated_pathname="$replicated_directory/$replicated_filename"
@@ -196,7 +196,7 @@ instance_ip=$(hostname -i)
 replicated_directory="/tmp/replicated"
 install_pathname="$replicated_directory/install.sh"
 
-%{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) ~}
+%{ if airgap_pathname == null ~}
 curl --create-dirs --output $install_pathname https://get.replicated.com/docker/terraformenterprise/active-active
 %{ endif ~}
 

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -198,10 +198,13 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathn
 instance_ip=$(hostname -i)
 replicated_directory="/tmp/replicated"
 install_pathname="$replicated_directory/install.sh"
-curl -o $install_pathname https://get.replicated.com/docker/terraformenterprise/active-active
+
+%{ if bootstrap_airgap_installation || airgap_url == null ~}
+curl --create-dirs --output $install_pathname https://get.replicated.com/docker/terraformenterprise/active-active
+%{ endif ~}
+
 chmod +x $install_pathname
 cd $replicated_directory
-
 $install_pathname \
 	bypass-firewalld-warning \
 	%{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -44,12 +44,12 @@ EOF
 
 certificate_config() {
 	%{ if certificate_secret != null ~}
-    echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a /var/log/ptfe.log
-	    %{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
-        # Obtain access token for Azure Key Vault
-        access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-        certificate_data_b64=$(curl --noproxy '*' ${certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-	    %{ endif ~}
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a /var/log/ptfe.log
+		%{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
+		# Obtain access token for Azure Key Vault
+		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+		certificate_data_b64=$(curl --noproxy '*' ${certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
+		%{ endif ~}
 
 	mkdir -p $(dirname ${tls_bootstrap_cert_pathname})
 	echo $certificate_data_b64 | base64 --decode > ${tls_bootstrap_cert_pathname}
@@ -60,11 +60,11 @@ certificate_config() {
 	%{ endif ~}
 	%{ if key_secret != null ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapKey" | tee -a /var/log/ptfe.log
-        %{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
-        # Obtain access token for Azure Key Vault
-        access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-        key_data_b64=$(curl --noproxy '*' ${key_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-    	%{ endif ~}
+		%{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
+		# Obtain access token for Azure Key Vault
+		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+		key_data_b64=$(curl --noproxy '*' ${key_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
+		%{ endif ~}
 
 	mkdir -p $(dirname ${tls_bootstrap_key_pathname})
 	echo $key_data_b64 | base64 --decode > ${tls_bootstrap_key_pathname}
@@ -77,11 +77,11 @@ certificate_config() {
 ca_config() {
 	%{ if ca_certificate_secret != null ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure CA cert" | tee -a /var/log/ptfe.log
-	    %{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
-        # Obtain access token for Azure Key Vault
-        access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-        ca_certificate_data_b64=$(curl --noproxy '*' ${ca_certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-	    %{ endif ~}
+		%{ if cloud == "azurerm" && bootstrap_airgap_installation ~}
+		# Obtain access token for Azure Key Vault
+		access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+		ca_certificate_data_b64=$(curl --noproxy '*' ${ca_certificate_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
+		%{ endif ~}
 
 	ca_certificate_directory="/dev/null"
 	if [[ $DISTRO_NAME == *"Red Hat"* ]]
@@ -127,12 +127,12 @@ retrieve_tfe_license() {
 	# Obtain access token for Azure Key Vault
 	access_token=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
 	license=$(curl --noproxy '*' ${tfe_license_secret.id}?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value)
-    echo $license | base64 -d > ${tfe_license_file_location}
+	echo $license | base64 -d > ${tfe_license_file_location}
 }
 
 bootstrap_airgap() {
 	log_pathname="/var/log/ptfe.log"
-    echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
+	echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
 
 	if [[ $DISTRO_NAME == *"Red Hat"* ]]
 	then
@@ -156,8 +156,8 @@ bootstrap_airgap() {
 	apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
 	apt-get --assume-yes autoremove
 	fi
-    
-    replicated_directory="/tmp/replicated"
+
+	replicated_directory="/tmp/replicated"
 	replicated_filename="replicated.tar.gz"
 	replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
 	replicated_pathname="$replicated_directory/$replicated_filename"
@@ -171,7 +171,7 @@ bootstrap_airgap() {
 }
 
 install_tfe() {
-    log_pathname="/var/log/ptfe.log"
+	log_pathname="/var/log/ptfe.log"
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathname
 
 	instance_ip=$(hostname -i)
@@ -182,7 +182,7 @@ install_tfe() {
     cd $replicated_directory
 
 	$install_pathname \
-        bypass-firewalld-warning \
+		bypass-firewalld-warning \
 		%{ if proxy_ip != null ~}
 		http-proxy="${proxy_ip}:${proxy_port}" \
 		additional-no-proxy="${no_proxy}" \
@@ -195,9 +195,9 @@ install_tfe() {
 		private-address=$instance_ip \
 		public-address=$instance_ip \
 		%{ if airgap_url != null ~}
-        airgap \
-        %{ endif ~}
-        | tee -a $log_pathname
+		airgap \
+		%{ endif ~}
+		| tee -a $log_pathname
 
 	if [[ $DISTRO_NAME == *"Red Hat"* ]]
 	then

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -20,8 +20,9 @@ variable "tfe_license_secret" {
   })
   description = <<-EOD
   The secrets manager secret name under which the Base64 encoded Terraform Enterprise license is stored.
-  NOTE: If bootstrap_airgap_installation is false, then it is expected that the TFE license will be put
-  on the path defined by tfe_license_file_location prior to running this module.
+  NOTE: If this is an airgapped installation, then it is expected that the TFE license will be put
+  on the path defined by tfe_license_file_location prior to running this module (i.e. on the virtual machine
+  image).
   EOD
 }
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -30,11 +30,6 @@ variable "airgap_url" {
   type        = string
 }
 
-variable "bootstrap_airgap_installation" {
-  type        = bool
-  description = "(Optional) A boolean to determine if the prerequisites for an airgapped installation should be installed."
-}
-
 variable "ca_certificate_secret" {
   type = object({
     id = string
@@ -42,16 +37,6 @@ variable "ca_certificate_secret" {
   description = <<-EOD
   A secret which contains the Base64 encoded version of a PEM encoded public certificate of a certificate
   authority (CA) to be trusted by the TFE instance(s).
-  EOD
-}
-
-variable "ca_certificate_data_b64" {
-  type        = string
-  default     = null
-  description = <<-EOD
-  (Optional ) This variable can be used if you are installing TFE in an airgapped installation. This value
-  should be the Base64 encoded version of a PEM encoded public certificate of a certificate authority (CA)
-  to be trusted by the TFE instance(s).
   EOD
 }
 
@@ -65,15 +50,6 @@ variable "certificate_secret" {
   EOD
 }
 
-variable "certificate_data_b64" {
-  type        = string
-  default     = null
-  description = <<-EOD
-  (Optional) This variable can be used if you are installing TFE in an airgapped installation. This
-  value should be the Base64 encoded version of a PEM encoded public certificate for the TFE instance(s).
-  EOD
-}
-
 variable "key_secret" {
   type = object({
     id = string
@@ -81,15 +57,6 @@ variable "key_secret" {
   description = <<-EOD
   A secret which contains the Base64 encoded version of a PEM encoded private key for the TFE
   instance(s).
-  EOD
-}
-
-variable "key_data_b64" {
-  type        = string
-  default     = null
-  description = <<-EOD
-  (Optional) This variable can be used if you are installing TFE in an airgapped installation. This
-  value should be the Base64 encoded version of a PEM encoded private key for the TFE instance(s).
   EOD
 }
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -1,10 +1,38 @@
 # General
 # -------
+variable "cloud" {
+  type        = string
+  description = "(Required) On which cloud is this Terraoform Enterprise installation being deployed?"
+  validation {
+    condition = (
+      var.cloud == "aws" ||
+      var.cloud == "azurerm" ||
+      var.cloud == "google"
+    )
+
+    error_message = "Supported values for cloud are 'aws', 'azurerm', or 'google'."
+  }
+}
+
 variable "tfe_license_secret" {
   type = object({
     id = string
   })
-  description = "The secrets manager secret name under which the Base64 encoded Terraform Enterprise license is stored."
+  description = <<-EOD
+  The secrets manager secret name under which the Base64 encoded Terraform Enterprise license is stored.
+  NOTE: If bootstrap_airgap_installation is false, then it is expected that the TFE license will be put
+  on the path defined by tfe_license_file_location prior to running this module.
+  EOD
+}
+
+variable "airgap_url" {
+  description = "The URL of a Replicated airgap package for Terraform Enterprise."
+  type        = string
+}
+
+variable "bootstrap_airgap_installation" {
+  type        = bool
+  description = "(Optional) A boolean to determine if the prerequisites for an airgapped installation should be installed."
 }
 
 variable "ca_certificate_secret" {
@@ -14,6 +42,16 @@ variable "ca_certificate_secret" {
   description = <<-EOD
   A secret which contains the Base64 encoded version of a PEM encoded public certificate of a certificate
   authority (CA) to be trusted by the TFE instance(s).
+  EOD
+}
+
+variable "ca_certificate_data_b64" {
+  type        = string
+  default     = null
+  description = <<-EOD
+  (Optional ) This variable can be used if you are installing TFE in an airgapped installation. This value
+  should be the Base64 encoded version of a PEM encoded public certificate of a certificate authority (CA)
+  to be trusted by the TFE instance(s).
   EOD
 }
 
@@ -27,13 +65,31 @@ variable "certificate_secret" {
   EOD
 }
 
+variable "certificate_data_b64" {
+  type        = string
+  default     = null
+  description = <<-EOD
+  (Optional) This variable can be used if you are installing TFE in an airgapped installation. This
+  value should be the Base64 encoded version of a PEM encoded public certificate for the TFE instance(s).
+  EOD
+}
+
 variable "key_secret" {
   type = object({
     id = string
   })
   description = <<-EOD
   A secret which contains the Base64 encoded version of a PEM encoded private key for the TFE
-  instance(s)
+  instance(s).
+  EOD
+}
+
+variable "key_data_b64" {
+  type        = string
+  default     = null
+  description = <<-EOD
+  (Optional) This variable can be used if you are installing TFE in an airgapped installation. This
+  value should be the Base64 encoded version of a PEM encoded private key for the TFE instance(s).
   EOD
 }
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -26,7 +26,12 @@ variable "tfe_license_secret" {
 }
 
 variable "airgap_url" {
-  description = "The URL of a Replicated airgap package for Terraform Enterprise."
+  description = <<-EOD
+  The URL of a Replicated airgap package for Terraform Enterprise.
+  NOTE: If this value is given, then this script will install the airgap installation prerequisites. The airgap
+  bundle should already be on the virtual machine image, and you would not use this variable if this were a truly
+  airgapped environment.
+  EOD 
   type        = string
 }
 


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/1181500399442529/1201788823511492/f
Relates to: https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/153

This branch adds airgapped installation functionality. It also cleans up the install script quite a bit, removing unnecessary functions (as they are not reused) and creating a new function for pulling secrets.

## How Has This Been Tested

I manually created a VM image [here](https://portal.azure.com/#@azure.hashicorptest.com/resource/subscriptions/28a5724f-1fd6-43d4-a425-2513eadcb490/resourceGroups/ptfeacc-rg/providers/Microsoft.Compute/galleries/tfe_vm_image_gallery/images/airgap/overview) which contained all of the prerequisites for an airgapped installation, including the airgap bundle and certificates. This image was used to test the `standalone_airgap` example.

The `standalone_airgap_dev` example assumes that none of the prerequisites exist, and it installs them and TFE with the airgap bundle.

All of the rest of the tests were run to ensure that all other functionality is still intact. 
- [x] [Azure TFE tests pass](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/153#issuecomment-1048948626)
- The following were tested locally either because they are only example submodules or because they are part of the ptfe-replicated tests which are blocked by [this issue](https://hashicorp.slack.com/archives/CKSBW3DU7/p1645206206664999).
    - [ ] Azure `standalone-external` passes _(I did test standalone_external, however, it currently has a failure on the main branch, too, so that will need to be troubleshooted later.)_
    - [x] Azure `standalone-poc` passes
    - [x] Azure `standalone-airgap` passes
    - [x] Azure `standalone-airgap-dev` passes

### Test Configuration

* Terraform Version: 
```
Terraform v1.1.5
on darwin_amd64
+ provider registry.terraform.io/hashicorp/azurerm v2.96.0
+ provider registry.terraform.io/hashicorp/random v3.0.1
+ provider registry.terraform.io/hashicorp/tls v3.1.0
```

## TFE Modules

### Did you add a new setting?

If yes, please check each box after you have have added an issue in the TFE modules to add this setting (after merging this branch):

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/153)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

This branch adds airgapped installation functionality to the `tfe_init` module.

## This PR makes me feel

![alone](https://media.giphy.com/media/hPf00LDJHBDSE/giphy.gif)