### PR TITLE
TF-440: Remove demo (poc) mode

### DIFF
--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -17,7 +17,6 @@ module "settings" {
   source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
-  installation_type = var.installation_type
   production_type   = var.production_type
   iact_subnet_list  = var.iact_subnet_list
   trusted_proxies   = local.trusted_proxies

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -4,10 +4,6 @@ locals {
       value = var.hostname
     }
 
-    installation_type = {
-      value = var.installation_type
-    }
-
     production_type = {
       value = var.production_type
     }
@@ -132,3 +128,4 @@ locals {
     }
   }
 }
+

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -53,34 +53,22 @@ variable "custom_image_tag" {
   EOD
 }
 
-variable "installation_type" {
-  type        = string
-  description = "(Required) Installation type for Terraform Enterprise"
-
-  validation {
-    condition = (
-      var.installation_type == "poc" ||
-      var.installation_type == "production"
-    )
-    error_message = "The installation type must be 'production' (recommended) or 'poc' (only used for demo-mode)."
-  }
-}
-
 variable "production_type" {
-  default     = null
+  default     = "disk"
   type        = string
   description = <<-EOD
-  If you have chosen 'production' for the installation_type, production_type is required:
-  external or disk
+	Where Terraform Enterprise application data will be stored. One of `external`
+	or `disk`. Choose `external` when storing application data in an external
+	object storage service and database. Choose `disk` when storing application
+	data in a directory on the Terraform Enterprise instance itself.
   EOD
 
   validation {
     condition = (
       var.production_type == "external" ||
-      var.production_type == "disk" ||
-      var.production_type == null
+      var.production_type == "disk"
     )
-    error_message = "The production type must be 'external' or 'disk'."
+    error_message = "The production_type must be 'external' or 'disk'."
   }
 }
 

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -61,7 +61,7 @@ variable "production_type" {
 	`external`, `disk`, or `null`. Choose `external` when storing application
 	data in an external object storage service and database. Choose `disk` when
 	storing application data in a directory on the Terraform Enterprise instance
-	itself. Let it `null` when you want Terraform Enterprise to use its own
+	itself. Leave it `null` when you want Terraform Enterprise to use its own
 	default.
   EOD
 

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -71,7 +71,7 @@ variable "production_type" {
       var.production_type == "disk" ||
       var.production_type == null
     )
-    error_message = "The production_type must be 'external' or 'disk'."
+    error_message = "The production_type must be 'external', 'disk', or omitted."
   }
 }
 

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -54,19 +54,22 @@ variable "custom_image_tag" {
 }
 
 variable "production_type" {
-  default     = "disk"
+  default     = null
   type        = string
   description = <<-EOD
-	Where Terraform Enterprise application data will be stored. One of `external`
-	or `disk`. Choose `external` when storing application data in an external
-	object storage service and database. Choose `disk` when storing application
-	data in a directory on the Terraform Enterprise instance itself.
+	Where Terraform Enterprise application data will be stored. Valid values are
+	`external`, `disk`, or `null`. Choose `external` when storing application
+	data in an external object storage service and database. Choose `disk` when
+	storing application data in a directory on the Terraform Enterprise instance
+	itself. Let it `null` when you want Terraform Enterprise to use its own
+	default.
   EOD
 
   validation {
     condition = (
       var.production_type == "external" ||
-      var.production_type == "disk"
+      var.production_type == "disk" ||
+      var.production_type == null
     )
     error_message = "The production_type must be 'external' or 'disk'."
   }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -56,12 +56,12 @@ variable "production_type" {
   default     = null
   type        = string
   description = <<-EOD
-	Where Terraform Enterprise application data will be stored. Valid values are
-	`external`, `disk`, or `null`. Choose `external` when storing application
-	data in an external object storage service and database. Choose `disk` when
-	storing application data in a directory on the Terraform Enterprise instance
-	itself. Leave it `null` when you want Terraform Enterprise to use its own
-	default.
+  Where Terraform Enterprise application data will be stored. Valid values are
+  `external`, `disk`, or `null`. Choose `external` when storing application
+  data in an external object storage service and database. Choose `disk` when
+  storing application data in a directory on the Terraform Enterprise instance
+  itself. Leave it `null` when you want Terraform Enterprise to use its own
+  default.
   EOD
 
   validation {


### PR DESCRIPTION
## Background

Removing the demo (`poc`) installation mode to get ready for the April release of Terraform Enterprise where it will be removed in the code.

This should not get merged until after the April release of Terraform Enterprise is released.

## How Has This Been Tested

Use the module and confirm the outputted settings file does not contain `installation_type` and that the `production_type` is `disk` for mounted disk installations and `external` for external services installations.

## TFE Modules

### Did you add a new setting?

No, I removed one.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/m9eG1qVjvN56H0MXt8/giphy.gif)
