### PR TITLE
secret input is string not object

### DIFF
--- a/modules/tfe_init/README.md
+++ b/modules/tfe_init/README.md
@@ -4,7 +4,7 @@ This module is used to create the script that will install Terraform Enterprise 
 
 ## Required variables
 
-* `tfe_license_secret` - string value for the TFE license secret name
+* `tfe_license_secret_id` - string value for the TFE license secret ID
 * `replicated_configuration` - output object from the [`settings` module](../settings) of the Replicated configuration
 * `tfe_configuration` - output object from the [`settings` module](../settings) of the TFE configuration
 
@@ -23,10 +23,10 @@ module "tfe_init" {
   replicated_configuration    = module.settings.replicated_configuration
 
   # Secrets
-  ca_certificate_secret = var.ca_certificate_secret
-  certificate_secret    = var.vm_certificate_secret
-  key_secret            = var.vm_key_secret
-  tfe_license_secret    = var.tfe_license_secret
+  ca_certificate_secret_id = var.ca_certificate_secret_id
+  certificate_secret_id    = var.vm_certificate_secret_id
+  key_secret_id            = var.vm_key_secret_id
+  tfe_license_secret_id    = var.tfe_license_secret_id
 
   # Proxy information
   proxy_ip   = var.proxy_ip

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -18,11 +18,11 @@ locals {
       airgap_pathname               = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
 
       # Secrets
-      ca_certificate_secret     = var.ca_certificate_secret
-      certificate_secret        = var.certificate_secret
-      key_secret                = var.key_secret
+      ca_certificate_secret_id  = var.ca_certificate_secret_id
+      certificate_secret_id     = var.certificate_secret_id
+      key_secret_id             = var.key_secret_id
       tfe_license_file_location = var.replicated_configuration.LicenseFileLocation
-      tfe_license_secret        = var.tfe_license_secret
+      tfe_license_secret_id     = var.tfe_license_secret_id
 
       # Proxy information
       proxy_ip   = var.proxy_ip

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -61,18 +61,18 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping proxy configuration" | 
 # -----------------------------------------------------------------------------
 # Configure TLS (if not an airgapped environment)
 # -----------------------------------------------------------------------------
-%{ if certificate_secret != null ~}
+%{ if certificate_secret_id != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapCert" | tee -a $log_pathname
-certificate_data_b64=$(get_base64_secrets ${certificate_secret.id})
+certificate_data_b64=$(get_base64_secrets ${certificate_secret_id})
 mkdir -p $(dirname ${tls_bootstrap_cert_pathname})
 echo $certificate_data_b64 | base64 --decode > ${tls_bootstrap_cert_pathname}
 %{ else ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapCert configuration" | tee -a $log_pathname
 %{ endif ~}
 
-%{ if key_secret != null ~}
+%{ if key_secret_id != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure TlsBootstrapKey" | tee -a $log_pathname
-key_data_b64=$(get_base64_secrets ${key_secret.id})
+key_data_b64=$(get_base64_secrets ${key_secret_id})
 mkdir -p $(dirname ${tls_bootstrap_key_pathname})
 echo $key_data_b64 | base64 --decode > ${tls_bootstrap_key_pathname}
 chmod 0600 ${tls_bootstrap_key_pathname}
@@ -94,9 +94,9 @@ else
 fi
 ca_cert_filepath="$ca_certificate_directory/tfe-ca-certificate.crt"
 
-%{ if ca_certificate_secret != null ~}
+%{ if ca_certificate_secret_id != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure CA cert" | tee -a $log_pathname
-ca_certificate_data_b64=$(get_base64_secrets ${ca_certificate_secret.id})
+ca_certificate_data_b64=$(get_base64_secrets ${ca_certificate_secret_id})
 
 mkdir -p $ca_certificate_directory
 echo $ca_certificate_data_b64 | base64 --decode > $ca_cert_filepath
@@ -139,9 +139,9 @@ fi
 # -----------------------------------------------------------------------------
 # Retrieve TFE license (if not an airgapped environment)
 # -----------------------------------------------------------------------------
-%{ if tfe_license_secret != null ~}
+%{ if tfe_license_secret_id != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Retrieve TFE license" | tee -a $log_pathname
-license=$(get_base64_secrets ${tfe_license_secret.id})
+license=$(get_base64_secrets ${tfe_license_secret_id})
 echo $license | base64 -d > ${tfe_license_file_location}
 %{ endif ~}
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -14,12 +14,10 @@ variable "cloud" {
   }
 }
 
-variable "tfe_license_secret" {
-  type = object({
-    id = string
-  })
+variable "tfe_license_secret_id" {
+  type = string
   description = <<-EOD
-  The secrets manager secret name under which the Base64 encoded Terraform Enterprise license is stored.
+  The secrets manager secret ID under which the Base64 encoded Terraform Enterprise license is stored.
   NOTE: If this is an airgapped installation, then it is expected that the TFE license will be put
   on the path defined by tfe_license_file_location prior to running this module (i.e. on the virtual machine
   image).
@@ -36,32 +34,26 @@ variable "airgap_url" {
   type        = string
 }
 
-variable "ca_certificate_secret" {
-  type = object({
-    id = string
-  })
+variable "ca_certificate_secret_id" {
+  type = string
   description = <<-EOD
-  A secret which contains the Base64 encoded version of a PEM encoded public certificate of a certificate
+  A secret ID which contains the Base64 encoded version of a PEM encoded public certificate of a certificate
   authority (CA) to be trusted by the TFE instance(s).
   EOD
 }
 
-variable "certificate_secret" {
-  type = object({
-    id = string
-  })
+variable "certificate_secret_id" {
+  type = string
   description = <<-EOD
-  A secret which contains the Base64 encoded version of a PEM encoded public certificate for the TFE
+  A secret ID which contains the Base64 encoded version of a PEM encoded public certificate for the TFE
   instance(s).
   EOD
 }
 
-variable "key_secret" {
-  type = object({
-    id = string
-  })
+variable "key_secret_id" {
+  type = string
   description = <<-EOD
-  A secret which contains the Base64 encoded version of a PEM encoded private key for the TFE
+  A secret ID which contains the Base64 encoded version of a PEM encoded private key for the TFE
   instance(s).
   EOD
 }


### PR DESCRIPTION
## Background

This branch simplifies the secret variable inputs so that it only takes a string, not an object, since only the secret ID is really needed. This allows for consistency across all three modules.

Relates: https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/158

## How has this been tested?
- [x] [Azure TFE Modules](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/158#issuecomment-1065559401) (GCP and AWS don't consume this module yet)
- [x] [ptfe-replicated tests](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated?branch=ah-test-secret-input&filter=all) pass

## This PR makes me feel

![simplify](https://media.giphy.com/media/IHnROpQICe4kE/giphy.gif)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201945699713385