### PR TITLE
add linting and fmt to PRs

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -50,10 +50,6 @@ jobs:
       with:
         tflint_version: v0.26.0
 
-    - name: Lint root module
-      run: |
-        tflint --config ${{ github.workspace }}/.tflint.hcl ${{ github.workspace }}
-
     - name: Lint modules directory in a loop
       run: |
         for m in $(ls -1d modules/*/)

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: hashicorp/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: false
@@ -40,7 +40,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: hashicorp/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: false

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -46,7 +46,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Terraform Lint
-      uses: terraform-linters/setup-tflint@v1
+      uses: hashicorp/setup-tflint@v1
       with:
         tflint_version: v0.26.0
 
@@ -63,12 +63,11 @@ jobs:
             ${{ github.workspace }}/${m}
         done
 
-    # TODO: Add back when Fixtures are added
-    # - name: Lint fixtures directory in a loop
-    #   run: |
-    #     for m in $(ls -1d fixtures/*/)
-    #     do
-    #       tflint \
-    #         --config ${{ github.workspace }}/.tflint.hcl \
-    #         ${{ github.workspace }}/${m}
-    #     done
+    - name: Lint fixtures directory in a loop
+      run: |
+        for m in $(ls -1d fixtures/*/)
+        do
+          tflint \
+            --config ${{ github.workspace }}/.tflint.hcl \
+            ${{ github.workspace }}/${m}
+        done

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -25,7 +25,7 @@ rule "terraform_documented_variables" {
 }
 
 rule "terraform_typed_variables" {
-  enabled = true
+  enabled = false
 }
 
 rule "terraform_naming_convention" {

--- a/fixtures/test_proxy_init/versions.tf
+++ b/fixtures/test_proxy_init/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    template = "~> 2.2"
+  }
 }

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -130,5 +130,9 @@ locals {
     user_token = {
       value = random_id.user_token.hex
     }
+
+    vault_path = {
+      value = var.vault_path
+    }
   }
 }

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -131,8 +131,5 @@ locals {
       value = random_id.user_token.hex
     }
 
-    vault_path = {
-      value = var.vault_path
-    }
   }
 }

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -130,6 +130,5 @@ locals {
     user_token = {
       value = random_id.user_token.hex
     }
-
   }
 }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -113,15 +113,6 @@ variable "tbw_image" {
   }
 }
 
-variable "vault_path" {
-  default     = null
-  type        = string
-  description = <<-EOD
-  (Optional) Path on the host system to store the vault files. If extern_vault_enable is set, this
-  has no effect.
-  EOD
-}
-
 # ------------------------------------------------------
 # Log Forwarding and Metrics
 # ------------------------------------------------------

--- a/modules/tfe_init/versions.tf
+++ b/modules/tfe_init/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    template = "~> 2.2"
+  }
 }


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/1181500399442529/1201752311630248/f

Security has implemented new rules for GitHub Actions based on [this RFC](https://docs.google.com/document/d/1yW0k3upxrmUyhJ4KG5RzjJzYm-uUjDXF10eskwCgL90/edit) that are apparently only enforced for newly created repositories (which includes this current repo). In order to be able to use the GitHub actions that we need for linting, I had to fork them to the HashiCorp GitHub organization.

## How has this been tested?

If you see the fmt and lint tests being run in this PR, then the changes worked. 

## TFE Modules

### Did you add a new setting?

No

## This PR makes me feel

![tidy up](https://media.giphy.com/media/f41Jox61hzoyfXXZLl/giphy.gif)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201752311630248