### PR TITLE
Gcp init utilities

### DIFF
--- a/modules/settings/tfe_base_external_config.tf
+++ b/modules/settings/tfe_base_external_config.tf
@@ -36,5 +36,5 @@ locals {
     }
   }
 
-  base_external_configs = local.pg_optional_configs != null && var.enable_active_active ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
+  base_external_configs = local.pg_optional_configs != null && (var.enable_active_active || var.production_type == "external") ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
 }

--- a/modules/settings/tfe_base_external_config.tf
+++ b/modules/settings/tfe_base_external_config.tf
@@ -36,5 +36,5 @@ locals {
     }
   }
 
-  base_external_configs = local.pg_optional_configs != null ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
+  base_external_configs = local.pg_optional_configs != null && var.enable_active_active ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
 }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -44,7 +44,6 @@ variable "capacity_memory" {
 }
 
 variable "custom_image_tag" {
-  default     = null
   type        = string
   description = <<-EOD
   (Required if tbw_image is 'custom_image'.) The name and tag for your alternative Terraform
@@ -95,7 +94,6 @@ variable "release_sequence" {
 }
 
 variable "tbw_image" {
-  default     = null
   type        = string
   description = <<-EOD
   Set this to 'custom_image' if you want to use an alternative Terraform build worker image,

--- a/modules/tfe_init/files/daemon.json
+++ b/modules/tfe_init/files/daemon.json
@@ -1,0 +1,4 @@
+{
+  "storage-driver": "overlay2",
+  "mtu": 1460
+}

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -5,8 +5,9 @@ locals {
     "${path.module}/templates/tfe.sh.tpl",
     {
       # Functions
-      get_base64_secrets = data.template_file.get_base64_secrets.rendered
-      install_packages   = data.template_file.install_packages.rendered
+      get_base64_secrets        = data.template_file.get_base64_secrets.rendered
+      install_packages          = data.template_file.install_packages.rendered
+      install_monitoring_agents = data.template_file.install_monitoring_agents.rendered
 
       # Configuration data
       cloud                       = var.cloud
@@ -18,6 +19,7 @@ locals {
       tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, null)
       airgap_url                  = var.airgap_url
       airgap_pathname             = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
+      enable_monitoring           = var.enable_monitoring
 
       # Secrets
       ca_certificate_secret_id  = var.ca_certificate_secret_id
@@ -48,5 +50,13 @@ data "template_file" "install_packages" {
   vars = {
     cloud        = var.cloud
     distribution = var.distribution
+  }
+}
+
+data "template_file" "install_monitoring_agents" {
+  template = file("${path.module}/templates/install_monitoring_agents.func")
+
+  vars = {
+    cloud = var.cloud
   }
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -11,6 +11,7 @@ locals {
 
       # Configuration data
       cloud                       = var.cloud
+      custom_image_tag            = try(var.tfe_configuration.custom_image_tag.value, null)
       disk_path                   = var.disk_path
       disk_device_name            = var.disk_device_name
       distribution                = var.distribution

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -10,20 +10,21 @@ locals {
       install_monitoring_agents = data.template_file.install_monitoring_agents.rendered
 
       # Configuration data
+      active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
+      airgap_url                  = var.airgap_url
+      airgap_pathname             = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
       cloud                       = var.cloud
       custom_image_tag            = try(var.tfe_configuration.custom_image_tag.value, null)
       disk_path                   = var.disk_path
       disk_device_name            = var.disk_device_name
       distribution                = var.distribution
-      active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
+      docker_config               = filebase64("${path.module}/files/daemon.json")
+      enable_monitoring           = var.enable_monitoring != null ? var.enable_monitoring : false
       replicated                  = base64encode(jsonencode(var.replicated_configuration))
       settings                    = base64encode(jsonencode(var.tfe_configuration))
       tls_bootstrap_cert_pathname = try(var.replicated_configuration.TlsBootstrapCert, null)
       tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, null)
-      airgap_url                  = var.airgap_url
-      airgap_pathname             = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
-      enable_monitoring           = var.enable_monitoring != null ? var.enable_monitoring : false
-
+      
       # Secrets
       ca_certificate_secret_id  = var.ca_certificate_secret_id
       certificate_secret_id     = var.certificate_secret_id

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -19,7 +19,7 @@ locals {
       tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, null)
       airgap_url                  = var.airgap_url
       airgap_pathname             = try(var.replicated_configuration.LicenseBootstrapAirgapPackagePath, null)
-      enable_monitoring           = var.enable_monitoring
+      enable_monitoring           = var.enable_monitoring != null ? var.enable_monitoring : false
 
       # Secrets
       ca_certificate_secret_id  = var.ca_certificate_secret_id
@@ -57,6 +57,7 @@ data "template_file" "install_monitoring_agents" {
   template = file("${path.module}/templates/install_monitoring_agents.func")
 
   vars = {
-    cloud = var.cloud
+    cloud        = var.cloud
+    distribution = var.distribution
   }
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -11,6 +11,8 @@ locals {
 
       # Configuration data
       cloud                       = var.cloud
+      disk_path                   = var.disk_path
+      disk_device_name            = var.disk_device_name
       distribution                = var.distribution
       active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
       replicated                  = base64encode(jsonencode(var.replicated_configuration))

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -24,7 +24,7 @@ locals {
       settings                    = base64encode(jsonencode(var.tfe_configuration))
       tls_bootstrap_cert_pathname = try(var.replicated_configuration.TlsBootstrapCert, null)
       tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, null)
-      
+
       # Secrets
       ca_certificate_secret_id  = var.ca_certificate_secret_id
       certificate_secret_id     = var.certificate_secret_id

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -25,6 +25,6 @@ function get_base64_secrets {
 	# OS: Agnostic
 	# Description: Pull the Base 64 encoded secrets from Google Secrets Manager
 
-	gcloud secrets versions access latest --secret=$secret_id | base64 --decode --ignore-garbage 
+	http_proxy="" https_proxy="" gcloud secrets versions access latest --secret="$secret_id"
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -18,3 +18,11 @@ function get_base64_secrets {
   /usr/local/bin/aws secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
 }
 %{ endif ~}
+
+%{ if cloud == "google" ~}
+function get_base64_secrets {
+  local secret_id=$1
+  # OS: Agnostic
+  echo "TODO"
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -1,28 +1,30 @@
 %{ if cloud == "azurerm" ~}
 function get_base64_secrets {
-  local secret_id=$1
-  # OS: Agnostic
-  # Description: Pull the Base 64 encoded secrets from Azure Key Vault
+	local secret_id=$1
+	# OS: Agnostic
+	# Description: Pull the Base 64 encoded secrets from Azure Key Vault
 
-  access_token=$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
-  curl -s --noproxy '*' $secret_id?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value
+	access_token=$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' -H Metadata:true | jq -r .access_token)
+	curl -s --noproxy '*' $secret_id?api-version=2016-10-01 -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer $access_token" | jq -r .value
 }
 %{ endif ~}
 
 %{ if cloud == "aws" ~}
 function get_base64_secrets {
-  local secret_id=$1
-  # OS: Agnostic
-  # Description: Pull the Base 64 encoded secrets from AWS Secrets Manager
+	local secret_id=$1
+	# OS: Agnostic
+	# Description: Pull the Base 64 encoded secrets from AWS Secrets Manager
 
-  /usr/local/bin/aws secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
+	/usr/local/bin/aws secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
 }
 %{ endif ~}
 
 %{ if cloud == "google" ~}
 function get_base64_secrets {
-  local secret_id=$1
-  # OS: Agnostic
-  echo "TODO"
+	local secret_id=$1
+	# OS: Agnostic
+	# Description: Pull the Base 64 encoded secrets from Google Secrets Manager
+
+	gcloud secrets versions access latest --secret=$secret_id | base64 --decode --ignore-garbage 
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/install_monitoring_agents.func
+++ b/modules/tfe_init/templates/install_monitoring_agents.func
@@ -1,46 +1,44 @@
 %{ if cloud == "azurerm" ~}
 function install_monitoring_agents {
-    local log_pathname=$1
+	local log_pathname=$1
 	:
 %{ endif ~}
 
 %{ if cloud == "aws" ~}
 function install_monitoring_agents {
-    local log_pathname=$1
+	local log_pathname=$1
 	:
 }
 %{ endif ~}
 
 %{ if cloud == "google" ~}
 function install_monitoring_agents {
-    local log_pathname=$1
-    monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
-    monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
-    echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
+	local log_pathname=$1
 
-    ## Copypasta from the original module code.  for reference only.
+	monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
+	monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
 
-    # monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
-    # monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
-    # echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
-    # curl -sS -o $monitoring_agent_pathname $monitoring_agent_url
-    # 
-    # echo "[Terraform Enterprise] Executing Cloud Monitoring agent script at '$monitoring_agent_pathname'" | tee -a $log_pathname
-    # chmod +x $monitoring_agent_pathname
-    # bash $monitoring_agent_pathname
-    # 
-    # echo "[Terraform Enterprise] Installing Cloud Monitoring agent" | tee -a $log_pathname
-    # if [[ $distribution == "ubuntu" ]]
-    # then
-    # apt-get --assume-yes update
-    # apt-get --assume-yes install stackdriver-agent
-    # apt-get --assume-yes autoremove
-    # elif [[ $distribution == "rhel" ]]
-    # then
-    # yum install --assumeyes stackdriver-agent
-    # fi
-    # 
-    # echo "[Terraform Enterprise] Starting Cloud Monitoring agent service" | tee -a $log_pathname
-    # service stackdriver-agent start
+	echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
+	monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
+	monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
+
+	echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
+	curl -sS -o $monitoring_agent_pathname $monitoring_agent_url
+
+	echo "[Terraform Enterprise] Executing Cloud Monitoring agent script at '$monitoring_agent_pathname'" | tee -a $log_pathname
+	chmod +x $monitoring_agent_pathname
+	bash $monitoring_agent_pathname
+
+	echo "[Terraform Enterprise] Installing Cloud Monitoring agent" | tee -a $log_pathname
+	%{ if distribution == "ubuntu" ~}
+	apt-get --assume-yes update
+	apt-get --assume-yes install stackdriver-agent
+	apt-get --assume-yes autoremove
+	%{ else ~}
+	yum install --assumeyes stackdriver-agent
+	%{ endif ~}
+
+	echo "[Terraform Enterprise] Starting Cloud Monitoring agent service" | tee -a $log_pathname
+	service stackdriver-agent start
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/install_monitoring_agents.func
+++ b/modules/tfe_init/templates/install_monitoring_agents.func
@@ -2,6 +2,7 @@
 function install_monitoring_agents {
 	local log_pathname=$1
 	:
+}
 %{ endif ~}
 
 %{ if cloud == "aws" ~}

--- a/modules/tfe_init/templates/install_monitoring_agents.func
+++ b/modules/tfe_init/templates/install_monitoring_agents.func
@@ -1,0 +1,47 @@
+%{ if cloud == "azurerm" ~}
+function install_monitoring_agents {
+    local log_pathname=$1
+	:
+%{ endif ~}
+
+%{ if cloud == "aws" ~}
+function install_monitoring_agents {
+    local log_pathname=$1
+	:
+}
+%{ endif ~}
+
+%{ if cloud == "google" ~}
+function install_monitoring_agents {
+    local log_pathname=$1
+    monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
+    monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
+    echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
+
+    ## Copypasta from the original module code.  for reference only.
+    # %{ if monitoring_enabled ~}
+    # monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
+    # monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
+    # echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
+    # curl -sS -o $monitoring_agent_pathname $monitoring_agent_url
+    # 
+    # echo "[Terraform Enterprise] Executing Cloud Monitoring agent script at '$monitoring_agent_pathname'" | tee -a $log_pathname
+    # chmod +x $monitoring_agent_pathname
+    # bash $monitoring_agent_pathname
+    # 
+    # echo "[Terraform Enterprise] Installing Cloud Monitoring agent" | tee -a $log_pathname
+    # if [[ $distribution == "ubuntu" ]]
+    # then
+    # apt-get --assume-yes update
+    # apt-get --assume-yes install stackdriver-agent
+    # apt-get --assume-yes autoremove
+    # elif [[ $distribution == "rhel" ]]
+    # then
+    # yum install --assumeyes stackdriver-agent
+    # fi
+    # 
+    # echo "[Terraform Enterprise] Starting Cloud Monitoring agent service" | tee -a $log_pathname
+    # service stackdriver-agent start
+    # %{ endif ~}
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/install_monitoring_agents.func
+++ b/modules/tfe_init/templates/install_monitoring_agents.func
@@ -19,7 +19,7 @@ function install_monitoring_agents {
     echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
 
     ## Copypasta from the original module code.  for reference only.
-    # %{ if monitoring_enabled ~}
+
     # monitoring_agent_url="https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh"
     # monitoring_agent_pathname="/tmp/add-monitoring-agent-repo.sh"
     # echo "[Terraform Enterprise] Downloading Cloud Monitoring agent script from '$monitoring_agent_url' to '$monitoring_agent_pathname'" | tee -a $log_pathname
@@ -42,6 +42,5 @@ function install_monitoring_agents {
     # 
     # echo "[Terraform Enterprise] Starting Cloud Monitoring agent service" | tee -a $log_pathname
     # service stackdriver-agent start
-    # %{ endif ~}
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/install_packages.func
+++ b/modules/tfe_init/templates/install_packages.func
@@ -31,7 +31,12 @@ function install_packages {
 
 %{ if cloud == "azurerm" ~}
 function install_packages {
-	# : empty function, no packages necessary
+	:
+}
+%{ endif ~}
+
+%{ if cloud == "google" ~}
+function install_packages {
 	:
 }
 %{ endif ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -130,9 +130,19 @@ lvresize -r -L 40G /dev/mapper/rootvg-varlv
 %{ endif ~}
 
 # -----------------------------------------------------------------------------
+# Patching GCP Yum repo configuration (if GCP environment)
+# -----------------------------------------------------------------------------
+%{ if cloud == "google" && distribution == "rhel" ~}
+echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
+# workaround for GCP RHEL 7 known issue 
+# https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
+sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
+yum makecache
+%{ endif ~}
+
+# -----------------------------------------------------------------------------
 # Install Monitoring Agents
 # -----------------------------------------------------------------------------
-
 %{ if enable_monitoring ~}
 install_monitoring_agents $log_pathname
 %{ endif ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -11,6 +11,17 @@ tfe_settings_file="ptfe-settings.json"
 tfe_settings_path="/etc/$tfe_settings_file"
 
 # -----------------------------------------------------------------------------
+# Patching GCP Yum repo configuration (if GCP environment)
+# -----------------------------------------------------------------------------
+%{ if cloud == "google" && distribution == "rhel" ~}
+echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
+# workaround for GCP RHEL 7 known issue 
+# https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
+sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
+yum makecache
+%{ endif ~}
+
+# -----------------------------------------------------------------------------
 # Install jq and cloud specific packages (if not an airgapped environment)
 # -----------------------------------------------------------------------------
 %{ if airgap_url == null || (airgap_url != null && airgap_pathname != null) ~}
@@ -127,17 +138,6 @@ pvresize /dev/disk/azure/root-part4
 # Then resize the logical volumes to meet TFE specs
 lvresize -r -L 10G /dev/mapper/rootvg-rootlv
 lvresize -r -L 40G /dev/mapper/rootvg-varlv
-%{ endif ~}
-
-# -----------------------------------------------------------------------------
-# Patching GCP Yum repo configuration (if GCP environment)
-# -----------------------------------------------------------------------------
-%{ if cloud == "google" && distribution == "rhel" ~}
-echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
-# https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
-sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
-yum makecache
 %{ endif ~}
 
 # -----------------------------------------------------------------------------

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -18,7 +18,6 @@ echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_
 # workaround for GCP RHEL 7 known issue 
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
-yum makecache
 %{ endif ~}
 
 # -----------------------------------------------------------------------------

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -4,6 +4,8 @@ set -euo pipefail
 
 ${get_base64_secrets}
 ${install_packages}
+${install_monitoring_agents}
+
 log_pathname="/var/log/ptfe.log"
 tfe_settings_file="ptfe-settings.json"
 tfe_settings_path="/etc/$tfe_settings_file"
@@ -125,6 +127,14 @@ pvresize /dev/disk/azure/root-part4
 # Then resize the logical volumes to meet TFE specs
 lvresize -r -L 10G /dev/mapper/rootvg-rootlv
 lvresize -r -L 40G /dev/mapper/rootvg-varlv
+%{ endif ~}
+
+# -----------------------------------------------------------------------------
+# Install Monitoring Agents
+# -----------------------------------------------------------------------------
+
+%{ if enable_monitoring ~}
+install_monitoring_agents $log_pathname
 %{ endif ~}
 
 # -----------------------------------------------------------------------------

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -264,7 +264,7 @@ $install_pathname \
 # -----------------------------------------------------------------------------
 # Add docker0 to firewalld (for Red Hat instances only)
 # -----------------------------------------------------------------------------
-%{ if distribution == "rhel" ~}
+%{ if distribution == "rhel" && cloud != "google" ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Disable SELinux (temporary)" | tee -a $log_pathname
 setenforce 0
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Add docker0 to firewalld" | tee -a $log_pathname

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -140,6 +140,34 @@ lvresize -r -L 40G /dev/mapper/rootvg-varlv
 %{ endif ~}
 
 # -----------------------------------------------------------------------------
+# Configure Mounted Disk Installation
+# -----------------------------------------------------------------------------
+%{ if disk_path != null ~}
+device="/dev/${disk_device_name}"
+echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
+
+if lsblk --fs $device | grep ext4
+then
+  echo "[Terraform Enterprise] EXT4 filesystem detected on disk at '$device'" | tee -a $log_pathname
+else
+  echo "[Terraform Enterprise] Creating EXT4 filesystem on disk at '$device'" | tee -a $log_pathname
+
+  mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard $device
+fi
+
+echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
+mkdir --parents ${disk_path}
+
+echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
+mount --options discard,defaults $device ${disk_path}
+chmod og+rw ${disk_path}
+
+echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
+echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab
+
+%{ endif ~}
+
+# -----------------------------------------------------------------------------
 # Install Monitoring Agents
 # -----------------------------------------------------------------------------
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -92,3 +92,15 @@ variable "enable_monitoring" {
   script? 
   EOD
 }
+
+# Mounted Disk
+# ------------
+variable "disk_device_name" {
+  description = "The name of the disk device on which Terraform Enterprise will store data in Mounted Disk mode."
+  type        = string
+}
+
+variable "disk_path" {
+  description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode."
+  type        = string
+}

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -84,3 +84,12 @@ variable "replicated_configuration" {
 variable "tfe_configuration" {
   description = "The settings that will be used to configure Terraform Enterprise."
 }
+
+variable "enable_monitoring" {
+  type        = bool
+  default     = false
+  description = <<-EOD
+  Should cloud appropriate monitoring agents be installed as a part of the TFE installation
+  script? 
+  EOD
+}

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -70,7 +70,6 @@ variable "proxy_ip" {
 }
 
 variable "proxy_port" {
-  default     = "3128"
   type        = string
   description = "Port that the proxy server will use"
 }
@@ -87,7 +86,7 @@ variable "tfe_configuration" {
 
 variable "enable_monitoring" {
   type        = bool
-  default     = false
+  default     = null
   description = <<-EOD
   Should cloud appropriate monitoring agents be installed as a part of the TFE installation
   script? 


### PR DESCRIPTION
## Background

Asana tasks:
* https://app.asana.com/0/1181500399442529/1201752311630258/f
* https://app.asana.com/0/1181500399442529/1201789596800947/f

This change adds support in the settings and tfe_init modules for GCP installations.

## How has this been tested?

Changes will trigger full `/test all` runs in:

- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/236)
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/163)
- [x] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/147)
- [x] [`ptfe-replicated` tests](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated?branch=ah-test-gcp_init_utilities&filter=all)


## This PR makes me feel

<img src="https://media4.giphy.com/media/xTg8AQjs4zKyi4x8e4/giphy-downsized-medium.gif"/>
