### PR TITLE
add workflow to run standalone-vault repo

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -1,0 +1,28 @@
+name: Pull Request Dispatcher
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  slash_command_dispatch:
+    name: Slash Command Dispatcher
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@2afb49dbaafaba8005860648bf7fc178637aca0d
+        with:
+          # The `public_repo` scope is required by this token to create repository_dispatch and workflow_dispatch
+          # events on public repositories. The default GITHUB_TOKEN does not support the `public_repo` scope.
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: |
+            test
+            destroy
+            help
+          permission: maintain
+          issue-type: pull-request
+          event-type-suffix: -command

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -1,0 +1,27 @@
+name: Pull Request Help Handler
+
+on:
+  repository_dispatch:
+    types:
+      - help-command
+
+jobs:
+  help:
+    name: Run help
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            > | Command | Description |
+            > | ------- | ----------- |
+            > | /test <all\|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes. |
+            > | /destroy <all\|test case name...> | Destroy any resources that may still be in Terraform state from previous tests. Unnamed arguments can be "all" to destroy all resources from all test cases or specific test case names to only destroy selected test case resources. |
+            > | /help | Shows this help message |
+          reaction-type: confused

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -1,0 +1,188 @@
+name: Pull Request Test Handler
+
+on:
+  repository_dispatch:
+    types:
+      - test-command
+
+jobs:
+  aws_standalone_vault:
+    name: Run tf-test on AWS Standalone Vault
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-standalone-vault') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/aws-standalone-vault
+      K6_WORK_DIR_PATH: ./tests/tfe-load-test
+      AWS_DEFAULT_REGION: us-east-2
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      # Checkout the branch of the AWS TFE module to be used to test changes
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.WORK_DIR_PATH }}
+          repository: hashicorp/terraform-aws-terraform-enterprise
+          persist-credentials: false
+
+      # Checkout the hashicorp/tfe-load-test repository
+      - name: Checkout TFE Load Test
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.K6_WORK_DIR_PATH }}
+          repository: hashicorp/tfe-load-test
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
+
+      - name: Install required tools
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
+        run: |
+          sudo apt-get install jq
+          curl -L $K6_URL | tar -xz --strip-components=1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.AWS_STANDALONE_VAULT_TFC_TOKEN }}
+          terraform_version: 1.1.5
+          terraform_wrapper: true
+
+      # Run Terraform commands between these comments vvv
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Terraform Validate
+        id: validate
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform validate -no-color
+
+      - name: Write GitHub Actions runner CIDR to Terraform Variables
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          echo "iact_subnet_list = [\"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"]" > github.auto.tfvars
+
+      - name: Terraform Apply
+        id: apply
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform apply -auto-approve -input=false -no-color
+
+      - name: Retrieve Health Check URL
+        id: retrieve-health-check-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw health_check_url
+
+      - name: Wait For TFE
+        id: wait-for-tfe
+        timeout-minutes: 15
+        env:
+          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
+        run: |
+          echo "Curling \`health_check_url\` for a return status of 200..."
+          while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
+
+      - name: Retrieve TFE URL
+        id: retrieve-tfe-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw tfe_url
+
+      - name: Retrieve IACT URL
+        id: retrieve-iact-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw iact_url
+
+      - name: Retrieve IACT
+        id: retrieve-iact
+        env:
+          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
+        run: |
+          token=$(curl --fail --retry 5 --verbose "$IACT_URL")
+          echo "::set-output name=token::$token"
+
+      - name: Retrieve Initial Admin User URL
+        id: retrieve-initial-admin-user-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw initial_admin_user_url
+
+      - name: Create Admin in TFE
+        id: create-admin
+        env:
+          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
+          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IACT: ${{ steps.retrieve-iact.outputs.token }}
+        run: |
+          echo \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
+            > ./payload.json
+          response=$( \
+            curl \
+            --fail \
+            --retry 5 \
+            --verbose \
+            --header 'Content-Type: application/json' \
+            --data @./payload.json \
+            "$IAU_URL"?token="$IACT")
+          echo "::set-output name=response::$response"
+
+      - name: Retrieve Admin Token
+        id: retrieve-admin-token
+        env:
+          RESPONSE: ${{ steps.create-admin.outputs.response }}
+        run: |
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
+
+      - name: Run k6 Smoke Test
+        id: run-smoke-test
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_PATHNAME: "./k6"
+          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
+          TFE_EMAIL: tf-onprem-team@hashicorp.com
+        run: |
+          make smoke-test
+
+      - name: Terraform Destroy
+        id: destroy
+        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      # Run Terraform commands between these comments ^^^
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform AWS Standalone Vault Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263701779363/f
This is the first of a few different pull requests that will be necessary to get a GHA workflow to be able to run a test from the AWS TFE repo. 

This branch will add the scaffolding, and I will be able to determine if I have the necessary components in place to check out the repos that I will need. Beyond that, it will not run the test until I add logic to add the TFC backend to the terraform provider block.

## How has this been tested?

It will be a series of trial-and-error pull requests, but they do not impact any other workflows.

## TFE Modules

### Did you add a new setting?

No

## This PR makes me feel

![experimentation](https://media.giphy.com/media/pziFUfKX1x52sQos2v/giphy.gif)
