### PR TITLE
add the tfc backend to module

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -30,6 +30,17 @@ jobs:
           repository: hashicorp/terraform-aws-terraform-enterprise
           persist-credentials: false
 
+      - name: Set Terraform Backend to TFC Workspace
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          sed --in-place 's/terraform {/terraform {\n\
+            backend "remote" {\n\
+              organization = "terraform-enterprise-modules-test"\n\
+              workspaces {\n\
+                name = "aws-standalone-vault"\n\
+              }\n\
+            }\n/' versions.tf
+
       # Checkout the hashicorp/tfe-load-test repository
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ further details.
 
 * This module requires Terraform version `0.13` or greater to be installed on
 the running machine.
+
+### Testing
+
+TODO


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263701779363/f
Relates: #22 

The current tests that are used in the `ptfe-replicated` CI don't use a TFC backend. But also, we don't want to add that block to the modules or else it would break the functionality for the current implementation. Therefore, we can add a block that adds the TFC backend as part of the testing workflow in this repo.

## How has this been tested?

Other than running this syntax locally to see if it works, it hasn't been tested. I'm going to test it in another PR when this is merged.

## This PR makes me feel

![we'll see](https://media.giphy.com/media/3og0IKrqHPZDLmk0k8/giphy.gif)
