### PR TITLE
change outputs in commands to match test module

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -141,7 +141,7 @@ jobs:
           IACT: ${{ steps.retrieve-iact.outputs.token }}
         run: |
           echo \
-            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
+            '{"username": "test", "email": "team-tf-enterprise@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
           response=$( \
             curl \
@@ -168,7 +168,7 @@ jobs:
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
           TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-          TFE_EMAIL: tf-onprem-team@hashicorp.com
+          TFE_EMAIL: team-tf-enterprise@hashicorp.com
         run: |
           make smoke-test
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -108,7 +108,7 @@ jobs:
         id: retrieve-health-check-url
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          terraform output -no-color -raw health_check_url
+          terraform output -no-color -raw ptfe_health_check
 
       - name: Wait For TFE
         id: wait-for-tfe
@@ -123,33 +123,21 @@ jobs:
         id: retrieve-tfe-url
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          terraform output -no-color -raw tfe_url
-
-      - name: Retrieve IACT URL
-        id: retrieve-iact-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw iact_url
+          terraform output -no-color -raw ptfe_endpoint
 
       - name: Retrieve IACT
         id: retrieve-iact
         env:
-          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
+          IACT_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}/admin/retrieve-iact"
         run: |
           token=$(curl --fail --retry 5 --verbose "$IACT_URL")
           echo "::set-output name=token::$token"
-
-      - name: Retrieve Initial Admin User URL
-        id: retrieve-initial-admin-user-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw initial_admin_user_url
 
       - name: Create Admin in TFE
         id: create-admin
         env:
           TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IAU_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}/admin/initial-admin-user"
           IACT: ${{ steps.retrieve-iact.outputs.token }}
         run: |
           echo \


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263701779363/f
Relates: #25 #24 #23 #22 

## How has this been tested?

The last run failed [here](https://github.com/hashicorp/terraform-random-tfe-utility/runs/6491056544?check_suite_focus=true#step:13:12) because it was using the outputs from the other TFE module tests, but the outputs that are used in the `ptfe-replicated` tests are different since that workflow works slightly differently. Therefore, I changed the commands in the GHA workflow to match the current outputs.

It will be tested after it is merged, as this is inconsequential to any current testing.

## This PR makes me feel

![output](https://media.giphy.com/media/xT5LMYn7lUepV1bCr6/giphy.gif)
