### PR TITLE
add destroy workflow

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -1,0 +1,82 @@
+name: Pull Request Destroy Handler
+
+on:
+  repository_dispatch:
+    types:
+      - destroy-command
+
+jobs:
+  aws_standalone_vault:
+    name: Destroy resources from AWS Standalone Vault
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-standalone-vault') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/aws-standalone-vault
+      AWS_DEFAULT_REGION: us-east-2
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      # Checkout the branch of the AWS TFE module to be used to test changes
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.WORK_DIR_PATH }}
+          repository: hashicorp/terraform-aws-terraform-enterprise
+
+      - name: Set Terraform Backend to TFC Workspace
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          sed --in-place 's/terraform {/terraform {\n\
+            backend "remote" {\n\
+              organization = "terraform-enterprise-modules-test"\n\
+              workspaces {\n\
+                name = "aws-standalone-vault"\n\
+              }\n\
+            }\n/' versions.tf
+
+      - name: Set Terraform Utility Module Sources
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+        run: |
+          sed --in-place "s/?ref=main/?ref=$SHA/" main.tf
+          sed --in-place "s/?ref=main/?ref=$SHA/" tests/standalone-vault/main.tf
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.AWS_STANDALONE_VAULT_TFC_TOKEN }}
+          terraform_version: 1.1.5
+          terraform_wrapper: true
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Terraform Destroy
+        id: destroy
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform AWS Standalone Vault Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           path: ${{ env.WORK_DIR_PATH }}
           repository: hashicorp/terraform-aws-terraform-enterprise
-          persist-credentials: false
 
       - name: Set Terraform Backend to TFC Workspace
         working-directory: ${{ env.WORK_DIR_PATH }}


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263701789869/f

This branch adds a destroy workflow to the testing CI.

Also, it removes the `persist_credentials` argument in the test workflow, as it is not needed. 

## How has this been tested?

It will be tested after it merges. 

## This PR makes me feel

![destroy robot](https://media.giphy.com/media/RMxBByXzC0xzxxwQ8x/giphy.gif)
