### PR TITLE
update new utility names

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -35,7 +35,7 @@ jobs:
             backend "remote" {\n\
               organization = "terraform-enterprise-modules-test"\n\
               workspaces {\n\
-                name = "aws-standalone-vault"\n\
+                name = "utility-aws-standalone-vault"\n\
               }\n\
             }\n/' versions.tf
 
@@ -110,7 +110,7 @@ jobs:
             backend "remote" {\n\
               organization = "terraform-enterprise-modules-test"\n\
               workspaces {\n\
-                name = "aws-active-active-rhel7-proxy"\n\
+                name = "utility-aws-active-active-rhel7-proxy"\n\
               }\n\
             }\n/' versions.tf
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -36,7 +36,7 @@ jobs:
             backend "remote" {\n\
               organization = "terraform-enterprise-modules-test"\n\
               workspaces {\n\
-                name = "aws-standalone-vault"\n\
+                name = "utility-aws-standalone-vault"\n\
               }\n\
             }\n/' versions.tf
 
@@ -228,7 +228,7 @@ jobs:
             backend "remote" {\n\
               organization = "terraform-enterprise-modules-test"\n\
               workspaces {\n\
-                name = "aws-active-active-rhel7-proxy"\n\
+                name = "utility-aws-active-active-rhel7-proxy"\n\
               }\n\
             }\n/' versions.tf
 


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202309885053139/f
Relates: https://github.com/hashicorp/ptfedev-infra/pull/432

When making the new workspaces, I realized that the utility workspaces needed to be identified for being run directly from this repo, otherwise they would be confused with the TFE module workspaces. This cannot be merged until the `ptfedev-infra` PR above is merged.

## How has this been tested?

It will be tested after merged.

## This PR makes me feel

![same but different](https://media.giphy.com/media/C6JQPEUsZUyVq/giphy.gif)
