### PR TITLE
update gcs_credentials var desc

### DIFF
--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -497,8 +497,10 @@ variable "gcs_credentials" {
   default     = null
   type        = string
   description = <<-EOD
-  (Required when object storage is in GCP) JSON blob containing the GCP credentials document.
-  Note: This is a string, so ensure values are properly escaped."
+  JSON blob containing the GCP credentials document. This is only required if object storage is in
+  GCP and the TFE instance(s) do(es) not have the service account attached to it, in which case the
+  instance(s) may authenticate without credentials.
+  Note: This is a string, so ensure values are properly escaped.
   EOD
 }
 


### PR DESCRIPTION
## Background

The following PR has a change that allows for this description will be correct.

Relates: https://github.com/hashicorp/ptfe-replicated/pull/1119
Asana: https://app.asana.com/0/1181500399442529/1202399662309086/f

This also means that `gcs_credentials` is now optional in our tests since all of our GCP instances have service accounts attached to them.

## How has this been tested?

See [this PR for testing](https://github.com/hashicorp/ptfe-replicated/pull/1119).

## This PR makes me feel

![who are you](https://media.giphy.com/media/xUySTIOsf7QxHx1gk0/giphy.gif)
