### PR TITLE
Remove template provider

### DIFF
--- a/fixtures/test_proxy_init/main.tf
+++ b/fixtures/test_proxy_init/main.tf
@@ -3,8 +3,8 @@ locals {
   mitmproxy_user_data_script = templatefile(
     "${path.module}/templates/mitmproxy.sh.tpl",
     {
-      get_base64_secrets    = data.template_file.get_base64_secrets.rendered
-      install_packages      = data.template_file.install_packages.rendered
+      get_base64_secrets    = local.get_base64_secrets
+      install_packages      = local.install_packages
       ca_certificate_secret = var.mitmproxy_ca_certificate_secret != null ? var.mitmproxy_ca_certificate_secret : ""
       ca_private_key_secret = var.mitmproxy_ca_private_key_secret != null ? var.mitmproxy_ca_private_key_secret : ""
       http_port             = local.mitmproxy_http_port
@@ -17,20 +17,12 @@ locals {
     "${path.module}/templates/squid.sh.tpl",
     { http_port = local.squid_http_port }
   )
-}
 
-data "template_file" "get_base64_secrets" {
-  template = file("${path.module}/templates/get_base64_secrets.func")
-
-  vars = {
+  get_base64_secrets = templatefile("${path.module}/templates/get_base64_secrets.func", {
     cloud = var.cloud
-  }
-}
+  })
 
-data "template_file" "install_packages" {
-  template = file("${path.module}/templates/install_packages.func")
-
-  vars = {
+  install_packages = templatefile("${path.module}/templates/install_packages.func", {
     cloud = var.cloud
-  }
+  })
 }

--- a/fixtures/test_proxy_init/versions.tf
+++ b/fixtures/test_proxy_init/versions.tf
@@ -1,7 +1,5 @@
 terraform {
   required_version = ">= 0.13"
 
-  required_providers {
-    template = "~> 2.2"
-  }
+  required_providers {}
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -5,9 +5,9 @@ locals {
     "${path.module}/templates/tfe.sh.tpl",
     {
       # Functions
-      get_base64_secrets        = data.template_file.get_base64_secrets.rendered
-      install_packages          = data.template_file.install_packages.rendered
-      install_monitoring_agents = data.template_file.install_monitoring_agents.rendered
+      get_base64_secrets        = local.get_base64_secrets
+      install_packages          = local.install_packages
+      install_monitoring_agents = local.install_monitoring_agents
 
       # Configuration data
       active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
@@ -38,30 +38,19 @@ locals {
       no_proxy   = var.tfe_configuration.extra_no_proxy.value
     }
   )
-}
 
-data "template_file" "get_base64_secrets" {
-  template = file("${path.module}/templates/get_base64_secrets.func")
-
-  vars = {
+  get_base64_secrets = templatefile("${path.module}/templates/get_base64_secrets.func", {
     cloud = var.cloud
-  }
-}
+  })
 
-data "template_file" "install_packages" {
-  template = file("${path.module}/templates/install_packages.func")
-
-  vars = {
+  install_packages = templatefile("${path.module}/templates/install_packages.func", {
     cloud        = var.cloud
     distribution = var.distribution
-  }
-}
+  })
 
-data "template_file" "install_monitoring_agents" {
-  template = file("${path.module}/templates/install_monitoring_agents.func")
-
-  vars = {
+  install_monitoring_agents = templatefile("${path.module}/templates/install_monitoring_agents.func", {
     cloud        = var.cloud
     distribution = var.distribution
-  }
+  })
+
 }

--- a/modules/tfe_init/versions.tf
+++ b/modules/tfe_init/versions.tf
@@ -1,7 +1,5 @@
 terraform {
   required_version = ">= 0.13"
 
-  required_providers {
-    template = "~> 2.2"
-  }
+  required_providers {}
 }


### PR DESCRIPTION
## Background

The `template` provider is deprecated and also does not have a `darwin_amd64` build. Let's remove it.

## How has this been tested?

TODO

## TFE Modules

### Did you add a new setting?

N/A

## This PR makes me feel

![optional gif describing your feelings about this pr]()