### PR TITLE
RHEL 8.* support

### DIFF
--- a/modules/tfe_init/templates/install_packages.func
+++ b/modules/tfe_init/templates/install_packages.func
@@ -4,7 +4,7 @@ function install_packages {
 	# OS: Agnostic
 	# Description: Install AWS packages
 
-	%{ if distribution == "rhel" ~}
+	%{ if distribution == "rhel" || distribution == "rhel8" ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install unzip and SSMAgent with yum" | tee -a $log_pathname
 	yum install -y \
 		firewalld \

--- a/modules/tfe_init/templates/install_packages.func
+++ b/modules/tfe_init/templates/install_packages.func
@@ -4,7 +4,7 @@ function install_packages {
 	# OS: Agnostic
 	# Description: Install AWS packages
 
-	%{ if distribution == "rhel" || distribution == "rhel8" ~}
+	%{ if distribution == "rhel" ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install unzip and SSMAgent with yum" | tee -a $log_pathname
 	yum install -y \
 		firewalld \

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+exit 1
 set -euo pipefail
 
 ${get_base64_secrets}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -105,7 +105,7 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping TlsBootstrapKey configu
 #------------------------------------------------------------------------------
 ca_certificate_directory="/dev/null"
 
-%{ if distribution == "rhel" || distribution == "rhel8"~}
+%{ if distribution == "rhel" ~}
 ca_certificate_directory=/usr/share/pki/ca-trust-source/anchors
 %{ else ~}
 ca_certificate_directory=/usr/local/share/ca-certificates/extra
@@ -124,7 +124,7 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping CA certificate configur
 
 if [ -f "$ca_cert_filepath" ]
 then
-	%{ if distribution == "rhel" || distribution == "rhel8"~}
+	%{ if distribution == "rhel" ~}
 	update-ca-trust
 
 	%{ else ~}
@@ -138,17 +138,18 @@ fi
 # -----------------------------------------------------------------------------
 # Resize RHEL logical volume (if Azure environment)
 # -----------------------------------------------------------------------------
-%{ if cloud == "azurerm" && (distribution == "rhel" || distribution == "rhel8")~}
+%{ if cloud == "azurerm" && distribution == "rhel" ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Resize RHEL logical volume" | tee -a $log_pathname
 
 # RHEL 8 disks in azure have a different partition mapping. Determine the release and change the partition ID appropriately.
-%{ if distribution == "rhel" ~}
-  partition_number=5
-  partition_link=root-part4-l
-%{ else ~}
+os_release=$(cat /etc/os-release | grep VERSION_ID | sed "s/VERSION_ID=\"\(.*\)\"/\1/g")
+if (( $(echo "$os_release >= 8.0" | bc -l ) )); then
   partition_number=2
   partition_link=root-part2
-%{ endif ~}
+else
+  partition_number=5
+  partition_link=root-part4-l
+fi
 # Because Microsoft is publishing only LVM-partitioned images, it is necessary to partition it to the specs that TFE requires.
 # First, extend the partition to fill available space
 growpart /dev/disk/azure/root $partition_number
@@ -212,7 +213,7 @@ replicated_directory="/etc/replicated"
 # Bootstrap airgapped environment with prerequisites (for dev/test environments)
 echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootstrapping an Airgapped Installation" | tee -a $log_pathname
 
-	%{ if distribution == "rhel" || distribution == "rhel8"~}
+	%{ if distribution == "rhel" ~}
 	yum install --assumeyes yum-utils
 	yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 	yum install --assumeyes docker-ce docker-ce-cli containerd.io
@@ -284,7 +285,7 @@ $install_pathname \
 # -----------------------------------------------------------------------------
 # Add docker0 to firewalld (for Red Hat instances only)
 # -----------------------------------------------------------------------------
-%{ if (distribution == "rhel" || distribution == "rhel8")&& cloud != "google" ~}
+%{ if distribution == "rhel" && cloud != "google" ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Disable SELinux (temporary)" | tee -a $log_pathname
 setenforce 0
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Add docker0 to firewalld" | tee -a $log_pathname

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -141,7 +141,7 @@ fi
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Resize RHEL logical volume" | tee -a $log_pathname
 
 terminal_partition=$(parted --script /dev/disk/cloud/azure_root u s p | tail -2 | head -n 1)
-terminal_partition_number=$(echo ${terminal_partition:0:3} | xargs)
+terminal_partition_number=$(echo $${terminal_partition:0:3} | xargs)
 terminal_partition_link=/dev/disk/cloud/azure_root-part$terminal_partition_number
 # Because Microsoft is publishing only LVM-partitioned images, it is necessary to partition it to the specs that TFE requires.
 # First, extend the partition to fill available space

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -13,8 +13,8 @@ variable "distribution" {
   type        = string
   description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
   validation {
-    condition     = contains(["rhel", "ubuntu"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel' or 'ubuntu'."
+    condition     = contains(["rhel", "rhel8", "ubuntu"], var.distribution)
+    error_message = "Supported values for distribution are 'rhel', 'rhel8', or 'ubuntu'."
   }
 }
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -13,8 +13,8 @@ variable "distribution" {
   type        = string
   description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
   validation {
-    condition     = contains(["rhel", "rhel8", "ubuntu"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel', 'rhel8', or 'ubuntu'."
+    condition     = contains(["rhel", "ubuntu"], var.distribution)
+    error_message = "Supported values for distribution are 'rhel', or 'ubuntu'."
   }
 }
 


### PR DESCRIPTION
## Background
This change adds support to the init scripts to support RHEL 8.* as a host vm platform.

## How has this been tested?
/test testing across all target clouds

## TFE Modules

### Did you add a new setting?
No

- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [x] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

<img src="https://media3.giphy.com/media/3ohhwxqQJzrSXnvWoM/giphy.gif"/>
