### PR TITLE
remove provider.tf from hcp vault fixture

### DIFF
--- a/fixtures/test_hcp_vault/outputs.tf
+++ b/fixtures/test_hcp_vault/outputs.tf
@@ -12,3 +12,9 @@ output "app_role_secret_id" {
   value       = vault_approle_auth_backend_role_secret_id.approle.secret_id
   description = "The secret ID of the Vault's app role."
 }
+
+output "token" {
+  value       = hcp_vault_cluster_admin_token.test.token
+  sensitive   = true
+  description = "The Vault token"
+}

--- a/fixtures/test_hcp_vault/provider.tf
+++ b/fixtures/test_hcp_vault/provider.tf
@@ -1,5 +1,0 @@
-# Credentials will be set via the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET
-provider "vault" {
-  address = hcp_vault_cluster.test.vault_public_endpoint_url
-  token   = hcp_vault_cluster_admin_token.test.token
-}


### PR DESCRIPTION
## Background

Removing provider file so that hcp/vault module provider is used.
[Replicated test](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/4604/workflows/022b982d-2786-496d-ba23-9d9f9f4be9cf) run on[ test branch](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/260)