### PR TITLE
add a PR trigger for external contributors

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -3,6 +3,8 @@ name: Create Jira Issue
 on:
   issues:
     types: [opened, closed, deleted, reopened]
+  pull_request_target:
+    types: [opened, closed, reopened]
   issue_comment:
     types: [created]
   workflow_call:


### PR DESCRIPTION
## Background

I realized that the automation is already set up to only allow for tasks to be created by pull requests if the contributors are external to our team, so I'm adding back in that trigger.
