### PR TITLE
Callable create-jira-workflow callable with inputs

### DIFF
--- a/.github/workflows/call-create-jira-issue.yml
+++ b/.github/workflows/call-create-jira-issue.yml
@@ -1,0 +1,17 @@
+name: Create Jira Issue
+
+on:
+  issues:
+    types: [opened, closed, deleted, reopened]
+  pull_request_target:
+    types: [opened, closed, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/create-jira-issue.yml
+    with:
+      github-team: Terraform-Enterprise
+      project: TFE
+    secrets: inherit

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,19 +1,23 @@
 name: Create Jira Issue
 
 on:
-  issues:
-    types: [opened, closed, deleted, reopened]
-  pull_request_target:
-    types: [opened, closed, reopened]
-  issue_comment:
-    types: [created]
   workflow_call:
-
+    inputs:
+      github-team:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+      issue-extra-fields:
+        type: string
+        default: "{}"
+        required: false
 jobs:
   sync:
     runs-on: ubuntu-latest
     name: Jira sync
-    steps:    
+    steps:
       - name: Login
         uses: atlassian/gajira-login@v2.0.0
         env:
@@ -41,12 +45,12 @@ jobs:
           if [[ "${{ contains(github.event.issue.labels.*.name, 'enhancement') }}" == "true" ]]; then LABELS+="\"enhancement\", "; fi
           if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
           echo "::set-output name=labels::${LABELS}"
-          
+
       - name: Check if team member
         if: github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
         id: is-team-member
         run: |
-          TEAM=Terraform-Enterprise
+          TEAM="${{ inputs.github-team }}"
           ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
           if [[ -n ${ROLE} ]]; then
             echo "Actor ${{ github.actor }} is a ${TEAM} team member"
@@ -58,19 +62,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_DISPATCH_TOKEN }}
 
+      - name: Build Extra fields
+        id: build-extra-fields
+        env:
+          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
+          EXTRA_FIELDS: |
+            { "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
+              "customfield_10371": { "value": "GitHub" },
+              "components": [{ "name": "${{ github.event.repository.name }}" }],
+              "labels": ${{ steps.set-ticket-labels.outputs.labels }}
+            }
+        run: |
+          echo "::set-output name=extra::$(echo '${{ env.EXTRA_FIELDS }}' '${{ inputs.issue-extra-fields }}' | jq -rcs '.[0] * .[1]')"
+
       - name: Create ticket
         if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' && steps.is-team-member.outputs.message == 'false' )
         uses: tomhjp/gh-action-jira-create@v0.1.3
         with:
-          project: TFE
+          project: "${{ inputs.project }}"
           issuetype: "${{ steps.set-ticket-type.outputs.type }}"
           summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
-          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
-          extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },            
-                          "components": [{ "name": "${{ github.event.repository.name }}" }],
-                          "labels": ${{ steps.set-ticket-labels.outputs.labels }}}'
+          extraFields: ${{ steps.build-extra-fields.outputs.extra }}
 
       - name: Search
         if: github.event.action != 'opened'


### PR DESCRIPTION
I had some trouble reusing the create jira issue workflow because it had some hardcoded values that were not usable for me. I refactored the workflow to accept some inputs, and reworked the workflow triggers to use it.

I also noticed that the is-team-member step seems to break if there are no bug/enhancement issue labels.

Example caller workflow (from other hashicorp repos)

```yaml
name: Create Jira Issue

on:
  issues:
    types: [opened, closed, deleted, reopened]
  pull_request_target:
    types: [opened, closed, reopened]
  issue_comment:
    types: [created]

jobs:
  call-workflow:
    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/create-jira-issue.yml@main
    with:
      github-team: Terraform-Enterprise
      project: TF
      issue-extra-fields: |
        { "customfield_10091": ["TF-CLI"] }
    secrets: inherit
```