### PR TITLE
Feature/amzn2 support

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -38,12 +38,13 @@ locals {
       # Proxy information
       proxy_ip   = var.proxy_ip
       proxy_port = var.proxy_port
-      no_proxy   = var.tfe_configuration.extra_no_proxy.value
+      no_proxy   = try(var.tfe_configuration.extra_no_proxy.value, null)
     }
   )
 
   get_base64_secrets = templatefile("${path.module}/templates/get_base64_secrets.func", {
-    cloud = var.cloud
+    cloud        = var.cloud
+    distribution = var.distribution
   })
 
   install_packages = templatefile("${path.module}/templates/install_packages.func", {

--- a/modules/tfe_init/templates/get_base64_secrets.func
+++ b/modules/tfe_init/templates/get_base64_secrets.func
@@ -14,8 +14,14 @@ function get_base64_secrets {
 	local secret_id=$1
 	# OS: Agnostic
 	# Description: Pull the Base 64 encoded secrets from AWS Secrets Manager
+  aws_region=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
+	%{ if distribution == "amzn2" ~}
+	/usr/bin/aws --region $aws_region secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
+	%{ else ~}
+	/usr/local/bin/aws --region $aws_region secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
+	%{ endif ~}
 
-	/usr/local/bin/aws secretsmanager get-secret-value --secret-id $secret_id | jq --raw-output '.SecretBinary,.SecretString | select(. != null)'
+
 }
 %{ endif ~}
 

--- a/modules/tfe_init/templates/install_packages.func
+++ b/modules/tfe_init/templates/install_packages.func
@@ -14,18 +14,23 @@ function install_packages {
 	systemctl start amazon-ssm-agent
 	systemctl enable firewalld
 	systemctl start firewalld
-	%{ else ~}
+	%{ endif ~}
+
+  %{ if distribution == "ubuntu" ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install unzip with apt-get" | tee -a $log_pathname
 	apt-get update -y
 	apt-get install -y unzip
 	%{ endif ~}
 
+  %{ if distribution == "amzn2" ~}
+ 	%{ else ~}
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install AWS CLI" | tee -a $log_pathname
 	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 	unzip awscliv2.zip
 	./aws/install
 	rm -f ./awscliv2.zip
 	rm -rf ./aws
+  %{ endif ~}
 }
 %{ endif ~}
 

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -14,7 +14,7 @@ tfe_settings_path="/etc/$tfe_settings_file"
 # -----------------------------------------------------------------------------
 %{ if cloud == "google" && distribution == "rhel" ~}
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
@@ -123,7 +123,7 @@ echo "[$(date +"%FT%T")] [Terraform Enterprise] Skipping CA certificate configur
 
 if [ -f "$ca_cert_filepath" ]
 then
-	%{ if distribution == "rhel" ~}
+	%{ if distribution == "rhel" || distribution == "amzn2" ~}
 	update-ca-trust
 
 	%{ else ~}
@@ -303,3 +303,8 @@ gcloud auth configure-docker --quiet ${split("/", custom_image_tag)[0]}
 echo "[Terraform Enterprise] Pulling custom worker image '${custom_image_tag}'" | tee -a
 docker pull ${custom_image_tag}
 %{ endif ~}
+
+# -----------------------------------------------------------------------------
+# Enable docker on reboot
+# -----------------------------------------------------------------------------
+systemctl enable docker

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -16,8 +16,8 @@ variable "distribution" {
   type        = string
   description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
   validation {
-    condition     = contains(["rhel", "ubuntu"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel', or 'ubuntu'."
+    condition     = contains(["amzn2", "rhel", "ubuntu"], var.distribution)
+    error_message = "Supported values for distribution are 'amzn2', 'rhel', or 'ubuntu'."
   }
 }
 
@@ -37,7 +37,7 @@ variable "airgap_url" {
   NOTE: If this value is given, then this script will install the airgap installation prerequisites. The airgap
   bundle should already be on the virtual machine image, and you would not use this variable if this were a truly
   airgapped environment.
-  EOD 
+  EOD
   type        = string
 }
 
@@ -92,7 +92,7 @@ variable "enable_monitoring" {
   default     = null
   description = <<-EOD
   Should cloud appropriate monitoring agents be installed as a part of the TFE installation
-  script? 
+  script?
   EOD
 }
 


### PR DESCRIPTION
## Background
Allows module to be used to crate tfe_init for Amazon Linux 2. And fixes some issues with aws cli requirements and parts which errors out when they are empty.

## How has this been tested?
Used to deploy a functional active-active cluster of PTFE

## TFE Modules
-

### Did you add a new setting?
Allowed for amzn2 to be passed as a valid distribution.