### PR TITLE
Add template to enable log forwarding for the clouds

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -11,6 +11,7 @@ locals {
       get_base64_secrets        = local.get_base64_secrets
       install_packages          = local.install_packages
       install_monitoring_agents = local.install_monitoring_agents
+      setup_log_forwarding      = local.setup_log_forwarding
 
       # Configuration data
       active_active               = var.tfe_configuration.enable_active_active.value == "1" ? true : false
@@ -23,10 +24,13 @@ locals {
       distribution                = var.distribution
       docker_config               = filebase64("${path.module}/files/daemon.json")
       enable_monitoring           = var.enable_monitoring != null ? var.enable_monitoring : false
+      log_destination             = try(var.log_settings.log_destination,null)
+      log_settings                = try(var.log_settings,null)
+      region                      = try(var.region,null)
       replicated                  = base64encode(jsonencode(var.replicated_configuration))
       settings                    = base64encode(jsonencode(var.tfe_configuration))
-      tls_bootstrap_cert_pathname = try(var.replicated_configuration.TlsBootstrapCert, null)
-      tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, null)
+      tls_bootstrap_cert_pathname = try(var.replicated_configuration.TlsBootstrapCert, "null")
+      tls_bootstrap_key_pathname  = try(var.replicated_configuration.TlsBootstrapKey, "null")
 
       # Secrets
       ca_certificate_secret_id  = var.ca_certificate_secret_id
@@ -56,4 +60,12 @@ locals {
     distribution = var.distribution
   })
 
+  setup_log_forwarding = templatefile("${path.module}/templates/setup_log_forwarding.func", {
+    cloud         = var.cloud
+    active_active = var.tfe_configuration.enable_active_active.value == "1" ? true : false
+    region        = var.region != null ? var.region : "none"
+    log_settings  = var.log_settings != null ? var.log_settings : {
+      log_destination = null
+    }
+  })
 }

--- a/modules/tfe_init/templates/setup_log_forwarding.func
+++ b/modules/tfe_init/templates/setup_log_forwarding.func
@@ -1,0 +1,119 @@
+%{ if cloud == "aws" ~}
+function setup_log_forwarding {
+
+    %{ if log_settings.log_destination == "cloudwatch_logs" ~}
+    cat <<EOF > fluent-bit.conf
+[OUTPUT]
+    Name               cloudwatch_logs
+    Match              *
+    region             ${ region }
+    log_group_name     ${ log_settings.cloudwatch_log_group_name }
+    log_stream_name    ${ log_settings.cloudwatch_log_stream_name }
+    auto_create_group  On
+EOF
+    %{ endif ~}
+
+    %{ if log_settings.log_destination == "s3" ~}
+    cat <<EOF > fluent-bit.conf
+[OUTPUT]
+    Name                          s3
+    Match                         *
+    bucket                        ${ log_settings.s3_bucket_name }
+    region                        ${ region }
+    total_file_size               250M
+    s3_key_format                 /$TAG/%Y/%m/%d/%H/%M/%S/$UUID.gz
+    s3_key_format_tag_delimiters  .-
+EOF
+   %{ endif ~}
+
+    %{ if log_settings.log_destination != null ~}
+        %{ if active_active ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with tfe-admin"
+        tfe-admin app-config set log_forwarding_enabled --value 1
+        tfe-admin app-config -k log_forwarding_config -v "$(cat fluent-bit.conf)"
+
+        %{ else ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with replicatedctl"
+        replicatedctl app-config set log_forwarding_enabled --value 1
+        replicatedctl app-config set log_forwarding_config --value "$(cat fluent-bit.conf)"
+        %{ endif ~}
+    %{ else ~}
+    echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding skipped"
+    %{ endif ~}
+}
+%{ endif ~}
+
+%{ if cloud == "azurerm" ~}
+function setup_log_forwarding {
+
+    %{ if log_settings.log_destination == "azure" ~}
+    cat <<EOF > fluent-bit.conf
+[OUTPUT]
+    name         azure
+    match        *
+    Customer_ID  log_settings.log_analytics_workspace_id
+    Shared_Key   log_settings.log_analytics_workspace_access_key
+EOF
+    %{ endif ~}
+
+    %{ if log_settings.log_destination == "azure_blob" ~}
+    cat <<EOF > fluent-bit.conf
+[OUTPUT]
+    name                   azure_blob
+    match                  *
+    account_name           log_settings.blob_storage_account_name
+    shared_key             log_settings.blob_storage_account_access_key
+    path                   logs
+    container_name         terraform_enterprise
+    auto_create_container  on
+    tls                    on
+EOF
+   %{ endif ~}
+
+	%{ if log_settings.log_destination != null ~}
+        %{ if active_active ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with tfe-admin"
+        tfe-admin app-config set log_forwarding_enabled --value 1
+        tfe-admin app-config -k log_forwarding_config -v "$(cat fluent-bit.conf)"
+
+        %{ else ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with replicatedctl"
+        replicatedctl app-config set log_forwarding_enabled --value 1
+        replicatedctl app-config set log_forwarding_config --value "$(cat fluent-bit.conf)"
+        %{ endif ~}
+    %{ else ~}
+    echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding skipped"
+    %{ endif ~}
+}
+%{ endif ~}
+
+%{ if cloud == "google" ~}
+function setup_log_forwarding {
+
+    %{ if log_settings.log_destination == "stackdriver" ~}
+    cat <<EOF > fluent-bit.conf
+[OUTPUT]
+    Name       stackdriver
+    Match      *
+    location   ${region}
+    namespace  terraform_enterprise
+    node_id    ${log_settings.stackdriver_hostname}
+    resource   generic_node
+   %{ endif ~}
+
+    %{ if log_settings.log_destination != null ~}
+        %{ if active_active ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with tfe-admin"
+        tfe-admin app-config set log_forwarding_enabled --value 1
+        tfe-admin app-config -k log_forwarding_config -v "$(cat fluent-bit.conf)"
+
+        %{ else ~}
+        echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding with replicatedctl"
+        replicatedctl app-config set log_forwarding_enabled --value 1
+        replicatedctl app-config set log_forwarding_config --value "$(cat fluent-bit.conf)"
+        %{ endif ~}
+    %{ else ~}
+    echo "[$(date +"%FT%T")] [Terraform Enterprise] Setup log forwarding skipped"
+    %{ endif ~}
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -4,6 +4,7 @@ set -euo pipefail
 ${get_base64_secrets}
 ${install_packages}
 ${install_monitoring_agents}
+${setup_log_forwarding}
 
 log_pathname="/var/log/ptfe.log"
 tfe_settings_file="ptfe-settings.json"
@@ -186,6 +187,13 @@ echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard
 # -----------------------------------------------------------------------------
 %{ if enable_monitoring ~}
 install_monitoring_agents $log_pathname
+%{ endif ~}
+
+# -----------------------------------------------------------------------------
+# Install Monitoring Agents
+# -----------------------------------------------------------------------------
+%{ if log_settings != null && log_destination != null && region != null ~}
+setup_log_forwarding
 %{ endif ~}
 
 # -----------------------------------------------------------------------------

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -65,6 +65,13 @@ variable "key_secret_id" {
   EOD
 }
 
+variable "region" {
+  type = string
+  nullable = true
+  default = null
+  description = "Enable this setting to enable log forwarding. This should be the region where your instaces will be deployed for log forwarding."
+}
+
 # Proxy
 # -----
 variable "proxy_ip" {
@@ -94,6 +101,99 @@ variable "enable_monitoring" {
   Should cloud appropriate monitoring agents be installed as a part of the TFE installation
   script? 
   EOD
+}
+
+# Added for log forwarding
+variable "log_settings" {
+  type = object({
+    log_destination = string
+    # AWS
+    cloudwatch_log_group_name  = optional(string) #Cloud Watch
+    cloudwatch_log_stream_name = optional(string) #Cloud Watch
+    s3_bucket_name             = optional(string) #S3 Bucket
+    # Azure
+    log_analytics_workspace_id         = optional(string) #Log Analytics Workspace
+    log_analytics_workspace_access_key = optional(string) #Log Analytics Workspace
+    blob_storage_account_name          = optional(string) #Storage Account
+    blob_storage_account_access_key    = optional(string) #Storage Account
+    # GCP
+    stackdriver_hostname = optional(string) #Stackdriver
+  })
+  description = "Please see https://developer.hashicorp.com/terraform/enterprise/admin/infrastructure/logging for configuration details."
+  nullable    = true
+  default     = null
+  # Log Destination
+  validation {
+    condition     = anytrue([
+      var.log_settings == null,
+      try(contains(["cloudwatch_logs", "s3", "azure", "azure_blob", "stackdriver"], var.log_settings.log_destination),false)
+    ])
+    error_message = "var.log_settings.log_destination must be 'cloudwatch','s3','azure','azure_blob', or 'stackdriver'"
+  }
+  # Cloud Watch Logs
+  validation {
+    condition = (
+      anytrue([
+        var.log_settings == null,
+        try(var.log_settings.log_destination != "cloudwatch_logs",true),
+        try(alltrue([
+          var.log_settings.cloudwatch_log_group_name != null,
+          var.log_settings.cloudwatch_log_stream_name != null
+        ]),false)
+      ])
+    )
+    error_message = "var.log_settings.cloudwatch_log_group_name and var.log_settings.cloudwatch_log_stream_name must not be null if var.log_settings.log_destination is 'cloudwatch_logs'"
+  }
+  # AWS S3 Bucket
+  validation {
+    condition = (
+      anytrue([
+        var.log_settings == null,
+        try(var.log_settings.log_destination != "s3",true),
+        try(var.log_settings.s3_bucket_name != null,false)
+      ])
+    )
+    error_message = "var.log_settings.s3_bucket_name must not be null if var.log_settings.log_destination is 's3'"
+  }
+  # Azure Log Analytics Workspace
+  validation {
+    condition = (
+      anytrue([
+        var.log_settings == null,
+        try(var.log_settings.log_destination != "azure",true),
+        try(alltrue([
+          var.log_settings.log_analytics_workspace_id != null,
+          var.log_settings.log_analytics_workspace_access_key != null
+        ]),false)
+      ])
+    )
+    error_message = "var.log_settings.log_analytics_workspace_id and log_analytics_workspace_access_key must not be null if var.log_settings.log_destination is 'azure'"
+  }
+  # Azure Storage Blob
+  validation {
+    condition = (
+      anytrue([
+        var.log_settings == null,
+        try(var.log_settings.log_destination != "azure_blob",true),
+        try(alltrue([
+          var.log_settings.blob_storage_account_name != null,
+          var.log_settings.blob_storage_account_access_key != null
+        ]),false)
+      ])
+    )
+    error_message = "var.log_settings.blob_storage_account_name and blob_storage_account_access_key must not be null if var.log_settings.log_destination is 'azure_blob'"
+  }
+  # GCP Stackdriver
+  validation {
+    condition = (
+      anytrue([
+        var.log_settings == null,
+        try(var.log_settings.log_destination != "stackdriver",true),
+        try(var.log_settings.stackdriver_hostname != null,false)
+      ])
+    )
+    error_message = "var.log_settings.stackdriver_hostname must not be null if var.log_settings.log_destination is 'stackdriver'"
+  }
 }
 
 # Mounted Disk


### PR DESCRIPTION
## Background

Found a gap in the init script where it would be beneficial to have log forwarding in the user_data for certain clouds. This is especially helpful if it is an autoscale group or scale set.

Relates OR Closes #0000

## How has this been tested?

Validated that it generated the script template correctly and did not affect existing templates. Have not tested the log forwarding settings in each of the clouds.

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [x] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
