### PR TITLE
test

### DIFF
--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -144,22 +144,6 @@ jobs:
         run: |
           sed --in-place '${{ inputs.TFC_workspace_substitution_pattern }}' versions.tf
 
-      - name: Create Terraform Backend to TFC Workspace for Utility Module
-        if: ${{ inputs.create_backend }}
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend.tf
-            terraform {
-              backend "remote" {
-                organization = "$TFC_ORGANIZATION"
-                  workspaces {
-                    name = "${{ inputs.TFC_workspace }}"
-                             }
-                             }
-                             }
-          EOF
       - name: Set Terraform Utility Module Sources
         if: ${{ inputs.utility_test }}
         working-directory: ${{ env.WORK_DIR_PATH }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -97,7 +97,7 @@ jobs:
       work_dir: ./tests/private-tcp-active-active
       k6_work_dir: ./tests/tfe-load-test
       pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
-      pull_request_ref: ah/verbose
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       TFC_token_secret_name: UTILITY_AZURE_PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/azure-private-tcp-active-active/utility-azure-private-tcp-active-active/
@@ -184,7 +184,13 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       TFC_token_secret_name: UTILITY_STANDALONE_EXTERNAL_RHEL8_WORKER_TFC_TOKEN
-      TFC_workspace_substitution_pattern: s/google-standalone-external-rhel8-worker/utility-google-standalone-external-rhel8-worker/
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "utility-google-standalone-external-rhel8-worker"\n\
+          }\n\
+        }\n/'
       TFC_workspace: utility-google-standalone-external-rhel8-worker
 
   google_standalone_mounted_disk:
@@ -205,7 +211,13 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       TFC_token_secret_name: UTILITY_GOOGLE_STANDALONE_MOUNTED_DISK_TFC_TOKEN
-      TFC_workspace_substitution_pattern: s/google-standalone-mounted-disk/utility-google-standalone-mounted-disk/
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "utility-google-standalone-mounted-disk"\n\
+          }\n\
+        }\n/'
       TFC_workspace: utility-google-standalone-mounted-disk
 
   aws_active_active_rhel7_proxy:

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -97,7 +97,7 @@ jobs:
       work_dir: ./tests/private-tcp-active-active
       k6_work_dir: ./tests/tfe-load-test
       pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
-      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_ref: ah/verbose
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       TFC_token_secret_name: UTILITY_AZURE_PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/azure-private-tcp-active-active/utility-azure-private-tcp-active-active/


### PR DESCRIPTION
## Background

[TF-8869](https://hashicorp.atlassian.net/browse/TF-8869)
This branch seeks to fix the faulty providers in the Google test scenarios. It updates the backends to use the "utility" prefixed workspaces. I will test this once it merges to `main`. 

[TF-8869]: https://hashicorp.atlassian.net/browse/TF-8869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ