### PR TITLE
add gcp tunneling credentials

### DIFF
--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -165,12 +165,16 @@ jobs:
           sudo apt-get install jq
           curl -L $K6_URL | tar -xz --strip-components=1
 
+      - name: Authenticate to GCP
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_TUNNELING_CREDENTIALS }}
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       
       - name: increasing_the_tcp_upload_bandwidth
         id: increasing_the_tcp_upload_bandwidth


### PR DESCRIPTION
## Background

https://hashicorp.atlassian.net/browse/TF-8869

The GCP workflow is missing the authentication with credentials that will allow it to use the `gcloud` cli to tunnel through the proxy for the k6 tests, as we do [here](https://github.com/hashicorp/terraform-google-terraform-enterprise/blob/main/.github/workflows/handler-test.yml#L269-L273) in the Google TFE module workflow.

It also remove unneeded arguments to `setup-cloud` that aren't used [here](https://github.com/hashicorp/terraform-google-terraform-enterprise/blob/main/.github/workflows/handler-test.yml#L275-L276).

This will be tested upon merge of this PR.