### PR TITLE
add quotes to instance IP variable

### DIFF
--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -268,8 +268,8 @@ $install_pathname \
 	%{if active_active ~}
 	disable-replicated-ui \
 	%{ endif ~}
-	private-address=$instance_ip \
-	public-address=$instance_ip \
+	private-address="$instance_ip" \
+	public-address="$instance_ip" \
 	%{ if airgap_pathname != null ~}
 	airgap \
 	%{ endif ~}


### PR DESCRIPTION
## Background

[TF-8869](https://hashicorp.atlassian.net/browse/TF-8869)

The installation in this instance was failing, and the cloud-init-source.log said `Error: unknown parameter "10.0.32.5"`, so I'm trying quotes around the IP address in the command to see if that's what it needs.

[TF-8869]: https://hashicorp.atlassian.net/browse/TF-8869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ