### PR TITLE
Migrated to tsccr-verified GH Action

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -46,9 +46,9 @@ jobs:
         persist-credentials: false
 
     - name: Setup Terraform Lint
-      uses: hashicorp/setup-tflint@v1
+      uses: terraform-linters/setup-tflint@a5a1af8c6551fb10c53f1cd4ba62359f1973746f # v3.1.1
       with:
-        tflint_version: v0.26.0
+        tflint_version: v3.1.1
 
     - name: Lint modules directory in a loop
       run: |

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup Terraform Lint
       uses: terraform-linters/setup-tflint@a5a1af8c6551fb10c53f1cd4ba62359f1973746f # v3.1.1
       with:
-        tflint_version: v3.1.1
+        tflint_version: v0.26.0
 
     - name: Lint modules directory in a loop
       run: |


### PR DESCRIPTION
## Background

Migrate tflint GitHub action from forked version to official maintained version, which was already reviewed during a TSCCR security review.

## How has this been tested?
-/-

## This PR makes me feel
![giphy](https://github.com/hashicorp/terraform-random-tfe-utility/assets/9531624/e1ca79a9-646a-4e71-b243-59206f6ac626)

