### PR TITLE
replace consolidated_services with consolidated_services_enabled

### DIFF
--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -36,8 +36,8 @@ locals {
       value = random_id.cookie_hash.hex
     }
 
-    consolidated_services = {
-      value = var.consolidated_services != null ? var.consolidated_services ? "1" : "0" : null
+    consolidated_services_enabled = {
+      value = var.consolidated_services_enabled != null ? var.consolidated_services_enabled ? "1" : "0" : null
     }
 
     custom_image_tag = {

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -37,7 +37,7 @@ variable "capacity_memory" {
   description = "The maximum amount of memory (in megabytes) that a Terraform plan or apply can use on the system; defaults to 512."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = null
   type        = bool
   description = "(Required) True if TFE uses consolidated services."


### PR DESCRIPTION
## Background

This updates the `settings` module, which is used to configure Replicated TFE installations, to use the `consolidated_services_enabled` variable since it was changed in this [PR to ptfe-replicated](https://github.com/hashicorp/ptfe-replicated/pull/1734).

## How has this been tested?
I tested this locally and will test in `ptfe-replicated` post merge.

## TFE Modules

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/306)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/226)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/270)
