### PR TITLE
use exact regex expressions for test names

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Public Active/Active
@@ -27,7 +27,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Private Active/Active
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Private TCP Active/Active
@@ -61,7 +61,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Standalone External
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-external') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-external' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Standalone External
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Standalone Mounted Disk
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Public Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Public Active/Active
@@ -125,7 +125,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Private Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Private Active/Active
@@ -142,7 +142,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Private TCP Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Private TCP Active/Active
@@ -159,7 +159,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Standalone External (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-external') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-external' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Standalone External
@@ -182,7 +182,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from Azure Standalone Mounted Disk (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       cloud: Azure
       test_name: Standalone Mounted Disk
@@ -206,7 +206,7 @@ jobs:
     uses: ./.github/workflows/google-destroy.yml
     secrets: inherit
     name: Destroy resources from Google Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-public-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-public-active-active' }}
     with:
       test_name: Google Public Active/Active
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -223,7 +223,7 @@ jobs:
     uses: ./.github/workflows/google-destroy.yml
     secrets: inherit
     name: Destroy resources from Google Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Private Active/Active
       utility_test: true
@@ -240,7 +240,7 @@ jobs:
     uses: ./.github/workflows/google-destroy.yml
     secrets: inherit
     name: Destroy resources from Google Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Private TCP Active/Active
       utility_test: true
@@ -257,7 +257,7 @@ jobs:
     uses: ./.github/workflows/google-destroy.yml
     secrets: inherit
     name: Destroy resources from Google Standalone External Rhel8 Worker
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-rhel8-worker') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external-rhel8-worker' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Standalone External Rhel8 Worker
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -274,7 +274,7 @@ jobs:
     uses: ./.github/workflows/google-destroy.yml
     secrets: inherit
     name: Destroy resources from Google Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Standalone Mounted Disk
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -292,7 +292,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Active-Active RHEL7 Proxy
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-active-active-rhel7-proxy') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-active-active-rhel7-proxy' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Active/Active RHEL7 Proxy
@@ -315,7 +315,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Private Active-Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Private Active/Active
@@ -332,7 +332,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Private TCP Active-Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Private TCP Active/Active
@@ -349,7 +349,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Public Active-Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Public Active/Active
@@ -366,7 +366,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Standalone Vault
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-standalone-vault') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-standalone-vault' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Standalone Vault
@@ -390,7 +390,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Active-Active RHEL7 Proxy (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-active-active-rhel7-proxy-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-active-active-rhel7-proxy-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Active/Active RHEL7 Proxy (Replicated)
@@ -413,7 +413,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Public Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Public Active/Active (Replicated)
@@ -430,7 +430,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Private Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Private Active/Active (Replicated)
@@ -447,7 +447,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Private TCP Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-tcp-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-tcp-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Private TCP Active/Active (Replicated)
@@ -464,7 +464,7 @@ jobs:
     uses: ./.github/workflows/destroy.yml
     secrets: inherit
     name: Destroy resources from AWS Standalone Vault (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       cloud: AWS
       test_name: Standalone Vault (Replicated)

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -24,4 +24,4 @@ jobs:
             > | /test <all\|full-aws\|full-azure\|full-google\|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory in each of the terraform-aws-terraform-enterprise, terraform-azurerm-terraform-enterprise, and terraform-google-terraform-enterprise module repositories. Unnamed arguments can be "all" to run all test cases, full-[aws\|azure\|google] to run all cloud specific cases, or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes. |
             > | /destroy <all\|full-aws\|full-azure\|full-google\|test case name...> | Destroy any resources that may still be in Terraform state from previous tests. Unnamed arguments can be "all" to destroy all resources from all test cases, full-[aws\|azure\|google] to destroy all resources from cloud specific cases, or specific test case names to only destroy selected test case resources. |
             > | /help | Shows this help message |
-          reaction-type: confused
+          reactions: confused

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -24,4 +24,45 @@ jobs:
             > | /test <all\|full-aws\|full-azure\|full-google\|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory in each of the terraform-aws-terraform-enterprise, terraform-azurerm-terraform-enterprise, and terraform-google-terraform-enterprise module repositories. Unnamed arguments can be "all" to run all test cases, full-[aws\|azure\|google] to run all cloud specific cases, or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes. |
             > | /destroy <all\|full-aws\|full-azure\|full-google\|test case name...> | Destroy any resources that may still be in Terraform state from previous tests. Unnamed arguments can be "all" to destroy all resources from all test cases, full-[aws\|azure\|google] to destroy all resources from cloud specific cases, or specific test case names to only destroy selected test case resources. |
             > | /help | Shows this help message |
+            >
+            > ## Test Case Names
+            >
+            > | Cloud   | FDO or Replicated | Test Case Name                                     |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | Azurerm | FDO               | azure-private-active-active                        |
+            > | Azurerm | FDO               | azure-private-tcp-active-active                    |
+            > | Azurerm | FDO               | azure-public-active-active                         |
+            > | Azurerm | FDO               | azure-standalone-external                          |
+            > | Azurerm | FDO               | azure-standalone-mounted-disk                      |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | Azurerm | Replicated        | azure-private-active-active-replicated             |
+            > | Azurerm | Replicated        | azure-private-tcp-active-active-replicated         |
+            > | Azurerm | Replicated        | azure-public-active-active-replicated              |
+            > | Azurerm | Replicated        | azure-standalone-external-replicated               |
+            > | Azurerm | Replicated        | azure-standalone-mounted-disk-replicated           |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | AWS     | FDO               | aws-private-active-active                          |
+            > | AWS     | FDO               | aws-private-tcp-active-active                      |
+            > | AWS     | FDO               | aws-public-active-active                           |
+            > | AWS     | FDO               | aws-active-active-rhel7-proxy                      |
+            > | AWS     | FDO               | aws-standalone-vault                               |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | AWS     | Replicated        | aws-private-active-active-replicated               |
+            > | AWS     | Replicated        | aws-private-tcp-active-active-replicated           |
+            > | AWS     | Replicated        | aws-public-active-active-replicated                |
+            > | AWS     | Replicated        | aws-active-active-rhel7-proxy-replicated           |
+            > | AWS     | Replicated        | aws-standalone-vault-replicated                    |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | GCP     | FDO               | google-private-active-active                       |
+            > | GCP     | FDO               | google-private-tcp-active-active                   |
+            > | GCP     | FDO               | google-public-active-active                        |
+            > | GCP     | FDO               | google-standalone-mounted-disk                     |
+            > | GCP     | FDO               | google-standalone-external-rhel8-worker            |
+            > | ------- | ----------------- | -------------------------------------------------- |
+            > | GCP     | Replicated        | google-private-active-active-replicated            |
+            > | GCP     | Replicated        | google-private-tcp-active-active-replicated        |
+            > | GCP     | Replicated        | google-public-active-active-replicated             |
+            > | GCP     | Replicated        | google-standalone-mounted-disk-replicated          |
+            > | GCP     | Replicated        | google-standalone-external-rhel8-worker-replicated |
+            > | ------- | ----------------- | -------------------------------------------------- |
           reactions: confused

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Standalone External
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-external') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-external' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Standalone External
       is_replicated_deployment: false
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Standalone Mounted Disk
       is_replicated_deployment: false
@@ -58,7 +58,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Public Active/Active
       is_replicated_deployment: false
@@ -76,7 +76,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Private Active/Active
       is_replicated_deployment: false
@@ -95,7 +95,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Private TCP Active/Active
       is_replicated_deployment: false
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Standalone External (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-external') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-external' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Standalone External
       is_replicated_deployment: true
@@ -138,7 +138,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Standalone Mounted Disk (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Standalone Mounted Disk (Replicated)
       is_replicated_deployment: true
@@ -162,7 +162,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Public Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Public Active/Active (Replicated)
       is_replicated_deployment: true
@@ -180,7 +180,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Private Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Private Active/Active (Replicated)
       is_replicated_deployment: true
@@ -199,7 +199,7 @@ jobs:
     uses: ./.github/workflows/azure-tests.yml
     secrets: inherit
     name: Run tf-test on Azure Private TCP Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-azure') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'azure-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-azure' }}
     with:
       test_name: Private TCP Active/Active
       is_replicated_deployment: true
@@ -218,7 +218,7 @@ jobs:
     uses: ./.github/workflows/google-tests.yml
     secrets: inherit
     name: Run tf-test on Google Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Public Active/Active
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -238,7 +238,7 @@ jobs:
     uses: ./.github/workflows/google-tests.yml
     secrets: inherit
     name: Run tf-test on Google Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Private Active/Active
       utility_test: true
@@ -258,7 +258,7 @@ jobs:
     uses: ./.github/workflows/google-tests.yml
     secrets: inherit
     name: Run tf-test on Google Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Private TCP Active/Active
       utility_test: true
@@ -278,7 +278,7 @@ jobs:
     uses: ./.github/workflows/google-tests.yml
     secrets: inherit
     name: Run tf-test on Google Standalone External Rhel8 Worker
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-rhel8-worker') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external-rhel8-worker' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Standalone External Rhel8 Worker
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -304,7 +304,7 @@ jobs:
     uses: ./.github/workflows/google-tests.yml
     secrets: inherit
     name: Run tf-test on Google Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'google-standalone-mounted-disk') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-google') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'google-standalone-mounted-disk' || github.event.client_payload.slash_command.args.unnamed.all == 'full-google' }}
     with:
       test_name: Google Standalone Mounted Disk
       module_repository_id: hashicorp/terraform-google-terraform-enterprise
@@ -330,7 +330,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Active-Active RHEL7 Proxy Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-active-active-rhel7-proxy') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-active-active-rhel7-proxy' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Active/Active RHEL7 Proxy
       utility_test: true
@@ -353,7 +353,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Private Active-Active Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Private Active/Active
       utility_test: true
@@ -370,7 +370,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Private TCP Active-Active Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-tcp-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-tcp-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Private TCP Active/Active
       utility_test: true
@@ -387,7 +387,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Public Active-Active Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Public Active/Active
       utility_test: true
@@ -404,7 +404,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Standalone Vault Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-standalone-vault') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws')}}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-standalone-vault' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Standalone Vault
       utility_test: true
@@ -428,7 +428,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Active-Active RHEL7 Proxy (Replicated) Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-active-active-rhel7-proxy-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-active-active-rhel7-proxy-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Active/Active RHEL7 Proxy (Replicated)
       utility_test: true
@@ -451,7 +451,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Public Active/Active (Replicated) Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Public Active/Active (Replicated)
       utility_test: true
@@ -468,7 +468,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Private Active/Active (Replicated) Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Private Active/Active (Replicated)
       utility_test: true
@@ -485,7 +485,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Private TCP Active/Active (Replicated) Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-private-tcp-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-private-tcp-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Private TCP Active/Active (Replicated)
       utility_test: true
@@ -502,7 +502,7 @@ jobs:
     uses: ./.github/workflows/aws-tests.yml
     secrets: inherit
     name: Test AWS Standalone Vault (Replicated) Scenario
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'aws-public-active-active-replicated') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'full-aws') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'aws-public-active-active-replicated' || github.event.client_payload.slash_command.args.unnamed.all == 'full-aws' }}
     with:
       test_name: Standalone Vault (Replicated)
       utility_test: true


### PR DESCRIPTION
## Background

As with [this change](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/230) to the workflow in the Azure TFE module, I am removing the `contains` function to more strictly enforce the correct regex for the test you are choosing to run. This is due to the doubling up of tests since FDO and that they are similarly named.

## How has this been tested?

The functionality worked in [this PR](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/230), but I will test again post merge.

## TFE Modules

### Did you add a new setting?

No
