### PR TITLE
fix TFC tokens for Replicated / Azure tests

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -119,7 +119,7 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       work_dir: ./tests/public-active-active
-      TFC_token_secret_name: UTILITY_AZURE_PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN
+      TFC_token_secret_name: UTILITY_AZURE_PUBLIC_ACTIVE_ACTIVE_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/azure-public-active-active/utility-azure-public-active-active-replicated/
   azure_private_active_active_replicated:
     uses: ./.github/workflows/destroy.yml
@@ -136,7 +136,7 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       work_dir: ./tests/private-active-active
-      TFC_token_secret_name: UTILITY_AZURE_PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN
+      TFC_token_secret_name: UTILITY_AZURE_PRIVATE_ACTIVE_ACTIVE_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/azure-private-active-active/utility-azure-private-active-active-replicated/
   azure_private_tcp_active_active_replicated:
     uses: ./.github/workflows/destroy.yml
@@ -153,7 +153,7 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       work_dir: ./tests/private-tcp-active-active
-      TFC_token_secret_name: UTILITY_AZURE_PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
+      TFC_token_secret_name: UTILITY_AZURE_PRIVATE_TCP_ACTIVE_ACTIVE_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/azure-private-tcp-active-active/utility-azure-private-tcp-active-active-replicated/
   azure_standalone_external_replicated:
     uses: ./.github/workflows/destroy.yml
@@ -170,7 +170,7 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       work_dir: ./tests/standalone-external
-      TFC_token_secret_name: UTILITY_AZURE_STANDALONE_EXTERNAL_TFC_TOKEN
+      TFC_token_secret_name: UTILITY_AZURE_STANDALONE_EXTERNAL_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
         backend "remote" {\n\
           organization = "terraform-enterprise-modules-test"\n\
@@ -193,7 +193,7 @@ jobs:
       pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
       pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
       work_dir: ./tests/standalone-mounted-disk
-      TFC_token_secret_name: UTILITY_AZURE_STANDALONE_MOUNTED_DISK_TFC_TOKEN
+      TFC_token_secret_name: UTILITY_AZURE_STANDALONE_MOUNTED_DISK_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
         backend "remote" {\n\
           organization = "terraform-enterprise-modules-test"\n\


### PR DESCRIPTION
## Background

While testing below, I realized that the destroy jobs had the wrong TFC token environment variables (copy/pasta). This fixes that.

## How has this been tested?

This will be tested post-merge.