### PR TITLE
move conditional in variable creation step

### DIFF
--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -180,12 +180,11 @@ jobs:
         run: terraform validate -no-color
 
       - name: Write Terraform Variables
-        if: ${{ inputs.enable_iact_subnet_list }} 
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
           ip_address=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
-          iact_subnet_list = ["$ip_address/32"]
+          ${{ inputs.enable_iact_subnet_list && 'iact_subnet_list = ["$ip_address/32"]' || '' }}
           is_replicated_deployment = ${{ inputs.is_replicated_deployment }}
           EOF
           


### PR DESCRIPTION
## Background

[TF-8611](https://hashicorp.atlassian.net/browse/TF-8611)

During testing I noticed that this conditional needs to be moved. It was there _before_ I had added the `is_replicated_deployment` variable, so it went unnoticed. Now, the `Write Terraform Variables` step will always run so that it can set the `is_replicated_deployment` variable, but it will only add the `iact_subnet_list` variable if `enable_iact_subnet_list` is `true`.


[TF-8611]: https://hashicorp.atlassian.net/browse/TF-8611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ