### PR TITLE
add disk_path to docker compose

### DIFF
--- a/modules/docker_compose_config/main.tf
+++ b/modules/docker_compose_config/main.tf
@@ -24,6 +24,7 @@ locals {
             HTTPS_PROXY                   = var.https_proxy != null ? "http://${var.https_proxy}" : null
             no_proxy                      = var.no_proxy != null ? join(",", var.no_proxy) : null
             NO_PROXY                      = var.no_proxy != null ? join(",", var.no_proxy) : null
+            TFE_DISK_PATH                 = var.disk_path
             TFE_HOSTNAME                  = var.hostname
             TFE_HTTP_PORT                 = var.http_port
             TFE_HTTPS_PORT                = var.https_port
@@ -79,7 +80,7 @@ locals {
           },
           local.disk ? [{
             type   = "volume"
-            source = "terraform-enterprise"
+            source = var.disk_path
             target = "/var/lib/terraform-enterprise"
           }] : [],
         ])

--- a/modules/docker_compose_config/main.tf
+++ b/modules/docker_compose_config/main.tf
@@ -24,7 +24,6 @@ locals {
             HTTPS_PROXY                   = var.https_proxy != null ? "http://${var.https_proxy}" : null
             no_proxy                      = var.no_proxy != null ? join(",", var.no_proxy) : null
             NO_PROXY                      = var.no_proxy != null ? join(",", var.no_proxy) : null
-            TFE_DISK_PATH                 = var.disk_path
             TFE_HOSTNAME                  = var.hostname
             TFE_HTTP_PORT                 = var.http_port
             TFE_HTTPS_PORT                = var.https_port

--- a/modules/docker_compose_config/main.tf
+++ b/modules/docker_compose_config/main.tf
@@ -79,7 +79,7 @@ locals {
             target = "/var/cache/tfe-task-worker/terraform"
           },
           local.disk ? [{
-            type   = "volume"
+            type   = "bind"
             source = var.disk_path
             target = "/var/lib/terraform-enterprise"
           }] : [],

--- a/modules/docker_compose_config/variables.tf
+++ b/modules/docker_compose_config/variables.tf
@@ -72,7 +72,7 @@ variable "database_user" {
 
 variable "disk_path" {
   default     = null
-  description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode."
+  description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode. Required when var.operational_mode is 'disk'."
   type        = string
 }
 

--- a/modules/docker_compose_config/variables.tf
+++ b/modules/docker_compose_config/variables.tf
@@ -70,6 +70,12 @@ variable "database_user" {
   description = "PostgreSQL user. Required when TFE_OPERATIONAL_MODE is external or active-active."
 }
 
+variable "disk_path" {
+  default     = null
+  description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode."
+  type        = string
+}
+
 variable "http_port" {
   default     = null
   type        = number


### PR DESCRIPTION
## Background

While testing a backup, @miguelhrocha discovered that the `disk_path` was not set for FDO deployments. It had gone unnoticed since we had not done a backup test yet using these modules as it was using the default docker mount.

## How has this been tested?

It is being tested in https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/319. 

## TFE Modules

### Did you add a new setting?

Yes, the `disk_path` was added to the following PRs:

- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/319)
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/242)
- [x] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/279)

## This PR makes me feel

![oops](https://media.giphy.com/media/tsIFjie7obBM4/giphy.gif)
