### PR TITLE
test

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -267,8 +267,8 @@ jobs:
       - name: Retrieve IACT
         run: |
           expiration=$(( $( date '+%s' ) + 90 ))
-          sleep_duration=30
-          until token=$(curl --fail --retry 5 \
+          sleep_duration=60
+          until token=$(curl --fail --retry 10 \
             --connect-timeout 10 \
             $USE_PROXY "$TFE_URL/admin/retrieve-iact")
           do


### PR DESCRIPTION
## Background

When testing AWS, I noticed that the `private-tcp-active-active-replicated` needed just a little bit longer for TFE to come up so that the automation could retrieve the IACT token. This gives it a little more time.
