### PR TITLE
pass registry name to tfe_init

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -37,7 +37,8 @@ locals {
       proxy_port = var.proxy_port
       no_proxy   = var.extra_no_proxy != null ? join(",", var.extra_no_proxy) : null
 
-      registry_username = var.registry_username
+      registry          = var.registry
       registry_password = var.registry_password
+      registry_username = var.registry_username
   })
 }

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -174,7 +174,7 @@ apt-get --assume-yes autoremove
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Installing TFE FDO" | tee -a $log_pathname
 hostname > /var/log/tfe-fdo.log
-docker login -u="${registry_username}" -p="${registry_password}" quay.io
+docker login -u="${registry_username}" -p="${registry_password}" ${registry}
 
 export HOST_IP=$(hostname -i)
 

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -97,14 +97,20 @@ variable "proxy_port" {
   description = "Port that the proxy server will use"
 }
 
-variable "registry_username" {
+variable "registry" {
   default     = null
-  description = "The username for the docker registry from which to pull the terraform_enterprise container images."
   type        = string
+  description = "The docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "registry_password" {
   default     = null
   description = "The password for the docker registry from which to pull the terraform_enterprise container images."
+  type        = string
+}
+
+variable "registry_username" {
+  default     = null
+  description = "The username for the docker registry from which to pull the terraform_enterprise container images."
   type        = string
 }


### PR DESCRIPTION
## Background

[Jira TF-10844](https://hashicorp.atlassian.net/browse/TF-10844)

This branch introduces a change to the `tfe_init` module to allow for login to different docker registries based on the newly introduced `registry` variable.

## How has this been tested?

An FDO test from each module has passed (links below). 

## TFE Modules

The following PRs have been submitted, and I will check them off as they are merged.
- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/320)
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/243)
- [x] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/280)
