### PR TITLE
Adding support for Podman on Google and Azurerm

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -15,7 +15,7 @@ locals {
       },
       rhel = {
         docker = "${path.module}/templates/aws.rhel.docker.tfe.sh.tpl",
-        podman = "${path.module}/templates/aws.rhel.podman.tfe.sh.tpl"
+        podman = "${path.module}/templates/aws.rhel.podman.tfe.sh.tpl",
       }
     },
     azurerm = {
@@ -25,7 +25,7 @@ locals {
       },
       rhel = {
         docker = "${path.module}/templates/azurerm.rhel.docker.tfe.sh.tpl",
-        podman = null
+        podman = "${path.module}/templates/azurerm.rhel.podman.tfe.sh.tpl",
       }
     }
     google = {
@@ -35,7 +35,7 @@ locals {
       },
       rhel = {
         docker = "${path.module}/templates/google.rhel.docker.tfe.sh.tpl",
-        podman = null
+        docker = "${path.module}/templates/google.rhel.podman.tfe.sh.tpl",
       }
     }
   }


### PR DESCRIPTION
## Background

This adds support for mounted disk, external and active active architectures for Podman in google and azure.

## How has this been tested?

Local testing through tf-onprem-dev-infra.

## TFE Modules

### Did you add a new setting?

No.

## This PR makes me feel

<img src="https://media0.giphy.com/media/wkA1l1lExztwk/giphy-downsized-medium.gif"/>
