### PR TITLE
fixing docker/podman template label

### DIFF
--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -35,7 +35,7 @@ locals {
       },
       rhel = {
         docker = "${path.module}/templates/google.rhel.docker.tfe.sh.tpl",
-        docker = "${path.module}/templates/google.rhel.podman.tfe.sh.tpl",
+        podman = "${path.module}/templates/google.rhel.podman.tfe.sh.tpl",
       }
     }
   }


### PR DESCRIPTION
## Background

#140 had a typo, labeling the google podman template as a docker template.  this change fixes that.

## This PR makes me feel

<img src="https://media3.giphy.com/media/BsQAVgY6ksvIY/giphy.gif"/>
