### PR TITLE
[TF-12420] Add usage_reporting_opt_out variable

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -24,6 +24,7 @@ locals {
       TFE_ENCRYPTION_PASSWORD       = random_id.enc_password.hex
       TFE_DISK_CACHE_VOLUME_NAME    = "terraform-enterprise_terraform-enterprise-cache"
       TFE_LICENSE_REPORTING_OPT_OUT = var.license_reporting_opt_out
+      TFE_USAGE_REPORTING_OPT_OUT   = var.usage_reporting_opt_out
       TFE_LICENSE                   = var.tfe_license
       TFE_TLS_CA_BUNDLE_FILE        = var.tls_ca_bundle_file != null ? var.tls_ca_bundle_file : null
       TFE_TLS_CERT_FILE             = var.cert_file

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -135,7 +135,14 @@ variable "https_proxy" {
 
 variable "license_reporting_opt_out" {
   type        = bool
+  default     = false
   description = "Whether to opt out of reporting licensing information to HashiCorp. Defaults to false if no value is given."
+}
+
+variable "usage_reporting_opt_out" {
+  type        = bool
+  default     = false
+  description = "Whether to opt out of TFE usage reporting to HashiCorp. Defaults to false if no value is given."
 }
 
 variable "key_file" {


### PR DESCRIPTION
This PR follows the example of the `license_reporting_opt_out` variable and adds the option to configure the `TFE_USAGE_REPORTING_OPT_OUT` environment variable via the terraform `usage_reporting_opt_out` variable.

This is not required by https://hashicorp.atlassian.net/browse/TF-12420, but it does make validation easier.