### PR TITLE
TF-11883 :: Uses quadlet to run tfe in podman installations

### DIFF
--- a/modules/tfe_init/functions.tf
+++ b/modules/tfe_init/functions.tf
@@ -16,5 +16,5 @@ locals {
     distribution      = var.distribution
     enable_monitoring = var.enable_monitoring != null ? var.enable_monitoring : false
   })
-  quadlet_unit = templatefile("${path.module}/templates/terraform-enterprise.kube.tpl")
+  quadlet_unit = templatefile("${path.module}/templates/terraform-enterprise.kube.tpl", {})
 }

--- a/modules/tfe_init/functions.tf
+++ b/modules/tfe_init/functions.tf
@@ -16,4 +16,5 @@ locals {
     distribution      = var.distribution
     enable_monitoring = var.enable_monitoring != null ? var.enable_monitoring : false
   })
+  quadlet_unit = templatefile("${path.module}/templates/terraform-enterprise.kube.tpl")
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -45,6 +45,7 @@ locals {
       get_base64_secrets        = local.get_base64_secrets
       install_packages          = local.install_packages
       install_monitoring_agents = local.install_monitoring_agents
+      quadlet_unit              = local.quadlet_unit
 
       active_active               = var.operational_mode == "active-active"
       cloud                       = var.cloud

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -135,14 +135,7 @@ cat > $tfe_dir/auth.json <<EOF
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
 cat > $tfe_dir/terraform-enterprise.kube <<EOF
-[Install]
-WantedBy=default.target
-
-[Service]
-Restart=always
-
-[Kube]
-Yaml=tfe.yaml
+${quadlet_unit}
 EOF
 
 cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -134,4 +134,14 @@ cat > $tfe_dir/auth.json <<EOF
 }
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
-podman play kube $tfe_dir/tfe.yaml
+cat > $tfe_dir/terraform-enterprise.kube <<EOF
+[Install]
+WantedBy=default.target
+
+[Kube]
+Yaml=tfe.yaml
+EOF
+
+cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/
+systemctl daemon-reload
+systemctl start terraform-enterprise.service

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -138,6 +138,9 @@ cat > $tfe_dir/terraform-enterprise.kube <<EOF
 [Install]
 WantedBy=default.target
 
+[Service]
+Restart=always
+
 [Kube]
 Yaml=tfe.yaml
 EOF

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -152,6 +152,9 @@ cat > $tfe_dir/terraform-enterprise.kube <<EOF
 [Install]
 WantedBy=default.target
 
+[Service]
+Restart=always
+
 [Kube]
 Yaml=tfe.yaml
 EOF

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -148,4 +148,14 @@ cat > $tfe_dir/auth.json <<EOF
 }
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
-podman play kube $tfe_dir/tfe.yaml
+cat > $tfe_dir/terraform-enterprise.kube <<EOF
+[Install]
+WantedBy=default.target
+
+[Kube]
+Yaml=tfe.yaml
+EOF
+
+cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/
+systemctl daemon-reload
+systemctl start terraform-enterprise.service

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -149,14 +149,7 @@ cat > $tfe_dir/auth.json <<EOF
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
 cat > $tfe_dir/terraform-enterprise.kube <<EOF
-[Install]
-WantedBy=default.target
-
-[Service]
-Restart=always
-
-[Kube]
-Yaml=tfe.yaml
+${quadlet_unit}
 EOF
 
 cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -148,14 +148,7 @@ cat > $tfe_dir/auth.json <<EOF
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
 cat > $tfe_dir/terraform-enterprise.kube <<EOF
-[Install]
-WantedBy=default.target
-
-[Service]
-Restart=always
-
-[Kube]
-Yaml=tfe.yaml
+${quadlet_unit}
 EOF
 
 cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -147,4 +147,14 @@ cat > $tfe_dir/auth.json <<EOF
 }
 EOF
 podman pull ${tfe_image} --authfile $tfe_dir/auth.json
-podman play kube $tfe_dir/tfe.yaml
+cat > $tfe_dir/terraform-enterprise.kube <<EOF
+[Install]
+WantedBy=default.target
+
+[Kube]
+Yaml=tfe.yaml
+EOF
+
+cp $tfe_dir/terraform-enterprise.kube $tfe_dir/tfe.yaml /etc/containers/systemd/
+systemctl daemon-reload
+systemctl start terraform-enterprise.service

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -151,6 +151,9 @@ cat > $tfe_dir/terraform-enterprise.kube <<EOF
 [Install]
 WantedBy=default.target
 
+[Service]
+Restart=always
+
 [Kube]
 Yaml=tfe.yaml
 EOF

--- a/modules/tfe_init/templates/terraform-enterprise.kube.tpl
+++ b/modules/tfe_init/templates/terraform-enterprise.kube.tpl
@@ -1,0 +1,8 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+Restart=always
+
+[Kube]
+Yaml=tfe.yaml


### PR DESCRIPTION
## Background

This change introduces podman management through Quadlet which is the primary systemd support method by redhat.

## How has this been tested?

Local testing in a running module-provisioned AWS TFE instance (mounted-disk)

## This PR makes me feel

<img src="https://media0.giphy.com/media/BncDOfWhsdZnMA8edi/giphy.gif"/>
