### PR TITLE
TF-10708: ensures ipv4 for instance ip for azure

### DIFF
--- a/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
+++ b/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
@@ -247,7 +247,13 @@ echo "[Terraform Enterprise] Skipping Airgapped Replicated download" | tee -a $l
 # Install Terraform Enterprise
 # -----------------------------------------------------------------------------
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install TFE" | tee -a $log_pathname
+
+%{ if cloud == "azurerm" ~}
+instance_ip=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq '.network.interface[0].ipv4.ipAddress[0].privateIpAddress' -r)
+%{ else ~}
 instance_ip=$(hostname -i)
+%{ endif ~}
+
 install_pathname="$replicated_directory/install.sh"
 
 %{ if airgap_pathname == null ~}


### PR DESCRIPTION
## Background

[Jira](https://hashicorp.atlassian.net/browse/TF-10708)

This includes a fix for the Azure host to only use the ipv4 private address when installing Replicated. Azure was intermittently also passing the ipv6 address, which caused a Replicated installation failure. 

Relates OR Closes #0000

## How has this been tested?

On an active/active instance and verified both VMs have functional Replicated platforms installed. 
<img width="2531" alt="image-20240227-204158" src="https://github.com/hashicorp/terraform-random-tfe-utility/assets/7529607/e004a4eb-da1a-4508-abe4-e5dbd102a259">

### Did you add a new setting?

No.

