### PR TITLE
Idempotent Init: Only mount if not mounted yet

### DIFF
--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -89,8 +89,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -88,8 +88,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -88,8 +88,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -102,8 +102,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -102,8 +102,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -88,8 +88,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
@@ -101,8 +101,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -101,8 +101,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -102,8 +102,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -128,8 +128,16 @@ else
 fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname
 echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard,defaults 0 2" >> /etc/fstab

--- a/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
+++ b/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
@@ -172,8 +172,16 @@ fi
 echo "[Terraform Enterprise] Creating mounted disk directory at '${disk_path}'" | tee -a $log_pathname
 mkdir --parents ${disk_path}
 
-echo "[Terraform Enterprise] Mounting disk '$device' to directory at '${disk_path}'" | tee -a $log_pathname
-mount --options discard,defaults $device ${disk_path}
+if findmnt -rno SOURCE,TARGET $device | grep -q $disk_path; then
+    echo "The device is already mounted at $disk_path." | tee -a $log_pathname
+else
+    if mount --options discard,defaults $device ${disk_path}; then
+        echo "Mount successful." | tee -a $log_pathname
+    else
+        echo "Failed to mount the device." | tee -a $log_pathname
+        exit 1
+    fi
+fi
 chmod og+rw ${disk_path}
 
 echo "[Terraform Enterprise] Configuring automatic mounting of '$device' to directory at '${disk_path}' on reboot" | tee -a $log_pathname


### PR DESCRIPTION
## Background
While I tested the [migration guide for Podman](https://github.com/hashicorp/ptfe-releases/pull/1134), and wanted to rollback, the startup script would not run through. 

During the Rollback steps, the startup script fails with

`mount: /opt/hashicorp/data: /dev/sdb already mounted on /opt/hashicorp/data.`

The solution to this is to unmount first with `umount /dev/sdb` and then rerun the script.
To prevent future engineers from this manual step, I suggest to adapt the initialization script to make it idempotent with respect to the mount. 

To make the script fully idempotent there might be more changes needed, but lets tackle this one step at a time. 

## How has this been tested?
I tested this adaption when I rolled back the podman installation to replicated. 

## This PR makes me feel
🔁 