### PR TITLE
Removes the non-consolidated feature flag.

### DIFF
--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -36,10 +36,6 @@ locals {
       value = random_id.cookie_hash.hex
     }
 
-    consolidated_services_enabled = {
-      value = var.consolidated_services_enabled != null ? var.consolidated_services_enabled ? "1" : "0" : null
-    }
-
     custom_image_tag = {
       value = var.custom_agent_image_tag != null ? null : var.custom_image_tag
     }
@@ -143,4 +139,3 @@ locals {
     }
   }
 }
-

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -37,12 +37,6 @@ variable "capacity_memory" {
   description = "The maximum amount of memory (in megabytes) that a Terraform plan or apply can use on the system; defaults to 512."
 }
 
-variable "consolidated_services_enabled" {
-  default     = null
-  type        = bool
-  description = "(Required) True if TFE uses consolidated services."
-}
-
 variable "custom_image_tag" {
   type        = string
   description = "(Required if tbw_image is 'custom_image'.) The name and tag for your alternative Terraform build worker image in the format <name>:<tag>. Default is 'hashicorp/build-worker:now'. If this variable is used, the 'tbw_image' variable must be 'custom_image'."


### PR DESCRIPTION
## Background

This change removes the non-consolidated feature flag from replicated settings. 

