### PR TITLE
Update the GHAs

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -18,13 +18,13 @@ jobs:
       contents: read
 
     steps:
-    - uses: hashicorp/checkout@v3
+    - uses: hashicorp/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: false
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.1.5
 
@@ -40,7 +40,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: hashicorp/checkout@v3
+    - uses: hashicorp/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: false

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -160,7 +160,7 @@ jobs:
           curl -L $K6_URL | tar -xz --strip-components=1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets[inputs.TFC_token_secret_name] }}

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -114,7 +114,7 @@ jobs:
       # test in the module repo.
       - name: Checkout
         if: ${{ ! inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -125,7 +125,7 @@ jobs:
       # the configuration to target the appropriate TFC workspace.
       - name: Checkout
         if: ${{ inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{inputs.module_repository_id}}
       
@@ -144,7 +144,7 @@ jobs:
           sed --in-place "s/?ref=main/?ref=$SHA/" ../../fixtures/test_proxy/main.tf
 
       - name: Checkout TFE Load Test
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
@@ -217,7 +217,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: ${{ inputs.ssh_private_key_secret_name != '' }}
-        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-access-key-id: ${{ secrets[inputs.aws_access_key_id] }}
           aws-secret-access-key: ${{ secrets[inputs.aws_secret_access_key] }}
@@ -325,7 +325,7 @@ jobs:
 
       - name: Update comment
         if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ inputs.pull_request_repo_name }}

--- a/.github/workflows/azure-tests.yml
+++ b/.github/workflows/azure-tests.yml
@@ -147,7 +147,7 @@ jobs:
           curl -L $K6_URL | tar -xz --strip-components=1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets[inputs.TFC_token_secret_name] }}

--- a/.github/workflows/azure-tests.yml
+++ b/.github/workflows/azure-tests.yml
@@ -101,7 +101,7 @@ jobs:
       # test in the module repo.
       - name: Checkout
         if: ${{ ! inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -112,7 +112,7 @@ jobs:
       # the configuration to target the appropriate TFC workspace.
       - name: Checkout
         if: ${{ inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{inputs.module_repository_id}}
       
@@ -131,7 +131,7 @@ jobs:
           sed --in-place "s/?ref=main/?ref=$SHA/" ../../fixtures/test_proxy/main.tf
 
       - name: Checkout TFE Load Test
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
@@ -207,7 +207,7 @@ jobs:
 
       - name: Update comment
         if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ inputs.pull_request_repo_name }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -119,7 +119,7 @@ jobs:
           sed --in-place "s/?ref=main/?ref=$SHA/" ../../main.tf
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets[inputs.TFC_token_secret_name] }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -90,7 +90,7 @@ jobs:
       # test in the module repo.
       - name: Checkout
         if: ${{ ! inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -101,7 +101,7 @@ jobs:
       # the configuration to target the appropriate TFC workspace.
       - name: Checkout
         if: ${{ inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{inputs.module_repository_id}}
       
@@ -138,7 +138,7 @@ jobs:
 
       - name: Update comment
         if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ inputs.pull_request_repo_name }}

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
         with:
           # The `public_repo` scope is required by this token to create repository_dispatch and workflow_dispatch
           # events on public repositories. The default GITHUB_TOKEN does not support the `public_repo` scope.

--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -99,7 +99,7 @@ jobs:
       # test in the module repo.
       - name: Checkout
         if: ${{ ! inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -110,7 +110,7 @@ jobs:
       # the configuration to target the appropriate TFC workspace.
       - name: Checkout
         if: ${{ inputs.utility_test }}
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: ${{inputs.module_repository_id}}
       
@@ -128,7 +128,7 @@ jobs:
           sed --in-place "s/?ref=main/?ref=$SHA/" ../../main.tf
 
       - name: Checkout TFE Load Test
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
@@ -145,12 +145,12 @@ jobs:
 
       - name: Authenticate to GCP
         id: auth
-        uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
         with:
           credentials_json: ${{ secrets.GCP_TUNNELING_CREDENTIALS }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.1
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT }}
       
@@ -255,7 +255,7 @@ jobs:
 
       - name: Update comment
         if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ inputs.pull_request_repo_name }}

--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -162,7 +162,7 @@ jobs:
           export CLOUDSDK_PYTHON_SITEPACKAGES=1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets[inputs.TFC_token_secret_name] }}

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}


### PR DESCRIPTION
Note: Might need to adjust the name of `google-github-actions/auth` from `google-tests.yml`

## Background
Updating GHAs due to node v16 deprecation

Relates OR Closes #0000

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
