### PR TITLE
[TF-15186] Upgrade HCP provider in vault fixture to ~> 0.90.0

### DIFF
--- a/fixtures/test_hcp_vault/versions.tf
+++ b/fixtures/test_hcp_vault/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.33.0"
+      version = "~> 0.90.0"
     }
     vault = {
       source  = "hashicorp/vault"


### PR DESCRIPTION
## Background

The latest version of the provider allows configuring a project_id, which we need for using this module in other HCP projects inside the `tf-onprem-dev-org`.

Merging is pretty safe, as this does not affect the public modules in any way. It is a fixture used by some examples, and module tests which we don't run anymore.
