### PR TITLE
[TF-15186] Add TFE_VAULT_TOKEN_RENEW env to vault_config in runtime configuration

### DIFF
--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -343,3 +343,8 @@ variable "vault_secret_id" {
   type        = string
   description = "Vault secret ID. External Vault only. Required when TFE_VAULT_USE_EXTERNAL is true."
 }
+
+variable "vault_token_renew" {
+  type = number
+  description = "Vault token renewal period in seconds. Required when TFE_VAULT_USE_EXTERNAL is true."
+}

--- a/modules/runtime_container_engine_config/vault_config.tf
+++ b/modules/runtime_container_engine_config/vault_config.tf
@@ -12,6 +12,7 @@ locals {
     TFE_VAULT_PATH         = var.vault_path
     TFE_VAULT_ROLE_ID      = var.vault_role_id
     TFE_VAULT_SECRET_ID    = var.vault_secret_id
+    TFE_VAULT_TOKEN_RENEW  = var.vault_token_renew
   }
 
   vault_cluster_address = {


### PR DESCRIPTION
## Background

The `TFE_VAULT_TOKEN_RENEW` configuration is not yet enabled for the FDO configuration modules. This PR addressess that.
