### PR TITLE
TF-15190 :: special character support

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -21,7 +21,7 @@ locals {
       TFE_HTTP_PORT                 = var.http_port
       TFE_HTTPS_PORT                = var.https_port
       TFE_OPERATIONAL_MODE          = var.operational_mode
-      TFE_ENCRYPTION_PASSWORD       = random_id.enc_password.hex
+      TFE_ENCRYPTION_PASSWORD       = random_password.enc_password.result
       TFE_DISK_CACHE_VOLUME_NAME    = "terraform-enterprise_terraform-enterprise-cache"
       TFE_LICENSE_REPORTING_OPT_OUT = var.license_reporting_opt_out
       TFE_USAGE_REPORTING_OPT_OUT   = var.usage_reporting_opt_out
@@ -230,6 +230,8 @@ locals {
   }
 }
 
-resource "random_id" "enc_password" {
-  byte_length = 16
+resource "random_password" "enc_password" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/modules/runtime_container_engine_config/outputs.tf
+++ b/modules/runtime_container_engine_config/outputs.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "docker_compose_yaml" {
-  value       = yamlencode(local.compose)
-  description = "A yaml object that will be used as the Docker Compose file for TFE deployment."
+  value       = base64encode(yamlencode(local.compose))
+  description = "A base 64 encoded yaml object that will be used as the Docker Compose file for TFE deployment."
 }
 
 output "podman_kube_yaml" {
-  value       = yamlencode(local.kube)
-  description = "A yaml object that will be used as the Podman kube.yaml file for TFE deployment"
+  value       = base64encode(yamlencode(local.kube))
+  description = "A base 64 encoded yaml object that will be used as the Podman kube.yaml file for TFE deployment"
 }

--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -131,8 +131,6 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -120,9 +120,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/tfe.yaml <<EOF
-${podman_kube_config}
-EOF
+echo ${podman_kube_config} | base64 -d > $tfe_dir/tfe.yaml
 
 cat > $tfe_dir/auth.json <<EOF
 {

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -119,8 +119,6 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -145,8 +145,6 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -134,9 +134,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/tfe.yaml <<EOF
-${podman_kube_config}
-EOF
+echo ${podman_kube_config} | base64 -d > $tfe_dir/tfe.yaml
 
 cat > $tfe_dir/auth.json <<EOF
 {

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -119,8 +119,6 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d

--- a/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
@@ -143,9 +143,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d
 

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -133,9 +133,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/tfe.yaml <<EOF
-${podman_kube_config}
-EOF
+echo ${podman_kube_config} | base64 -d > $tfe_dir/tfe.yaml
 
 cat > $tfe_dir/auth.json <<EOF
 {

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -134,9 +134,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d
 

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -181,9 +181,7 @@ export HOST_IP=$(hostname -i)
 tfe_dir="/etc/tfe"
 mkdir -p $tfe_dir
 
-cat > $tfe_dir/compose.yaml <<EOF
-${docker_compose}
-EOF
+echo ${docker_compose} | base64 -d > $tfe_dir/compose.yaml
 
 docker compose -f /etc/tfe/compose.yaml up -d
 


### PR DESCRIPTION
## Background

This change adds deeper support for special characters in DB, Redis, and encryption passwords by:
-  escaping sensitive fields in compose configuration
- changing enc_password generation to use a non-hex key with special characters enumerated
- base64 encoding container runtime config and then decoding it inline in userdata scripts to avoid managing heredoc escapes

## How has this been tested?

Local testing on a fork of this repo.  Additional testing will take place against this branch after it has been published with results reported below.


## This PR makes me feel

<img src="https://media4.giphy.com/media/3oEjHN4MtbSqEe4D8Q/giphy.gif"/>
