### PR TITLE
[TF-15070] Make active-active logic dependent on production_type

### DIFF
--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -25,7 +25,6 @@ module "settings" {
 
   # Replicated Base Configuration
   hostname                    = module.load_balancer.fqdn
-  enable_active_active        = local.active_active
   tfe_license_file_location   = var.tfe_license_file_location
   tls_bootstrap_cert_pathname = var.tls_bootstrap_cert_pathname
   tls_bootstrap_key_pathname  = var.tls_bootstrap_key_pathname

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
+  has_external_storage = var.production_type == "active-active" || var.production_type == "external"
   base_configs = {
     hostname = {
       value = var.hostname
@@ -93,9 +94,8 @@ locals {
     }
 
     placement = {
-      value = (var.production_type == "external" && var.s3_bucket != null) ? "placement_s3" : (
-        var.production_type == "external" && var.azure_account_name != null) ? "placement_azure" : (
-      var.production_type == "external" && var.gcs_bucket != null) ? "placement_gcs" : null
+      value = (
+      local.has_external_storage && var.s3_bucket != null) ? "placement_s3" : (local.has_external_storage && var.azure_account_name != null) ? "placement_azure" : (local.has_external_storage && var.gcs_bucket != null) ? "placement_gcs" : null
     }
 
     registry_session_encryption_key = {

--- a/modules/settings/tfe_base_config.tf
+++ b/modules/settings/tfe_base_config.tf
@@ -94,8 +94,7 @@ locals {
     }
 
     placement = {
-      value = (
-      local.has_external_storage && var.s3_bucket != null) ? "placement_s3" : (local.has_external_storage && var.azure_account_name != null) ? "placement_azure" : (local.has_external_storage && var.gcs_bucket != null) ? "placement_gcs" : null
+      value = (local.has_external_storage && var.s3_bucket != null) ? "placement_s3" : (local.has_external_storage && var.azure_account_name != null) ? "placement_azure" : (local.has_external_storage && var.gcs_bucket != null) ? "placement_gcs" : null
     }
 
     registry_session_encryption_key = {

--- a/modules/settings/tfe_base_external_config.tf
+++ b/modules/settings/tfe_base_external_config.tf
@@ -4,7 +4,7 @@
 locals {
   pg_configs = {
     enable_active_active = {
-      value = var.enable_active_active != null ? var.enable_active_active ? "1" : "0" : null
+      value = var.production_type == "active-active" ? "1" : "0"
     }
 
     pg_dbname = {
@@ -39,5 +39,5 @@ locals {
     }
   }
 
-  base_external_configs = local.pg_optional_configs != null && (var.enable_active_active || var.production_type == "external") ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
+  base_external_configs = local.pg_optional_configs != null && (var.production_type == "active-active" || var.production_type == "external") ? (merge(local.pg_configs, local.pg_optional_configs)) : local.pg_configs
 }

--- a/modules/settings/tfe_redis_config.tf
+++ b/modules/settings/tfe_redis_config.tf
@@ -24,5 +24,5 @@ locals {
     }
   }
 
-  redis_configuration = var.enable_active_active ? local.redis_configs : {}
+  redis_configuration = var.production_type == "active-active" ? local.redis_configs : {}
 }

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -6,7 +6,7 @@
 # values, but the variable default is set to null. This is because this module will only add
 # values to the final configuration that are set, and if they are left unset and null, then
 # the TFE installation will use defaults set by the Replicated configuration for the TFE
-# installation. You can find this documented here: 
+# installation. You can find this documented here:
 # https://www.terraform.io/enterprise/install/automated/automating-the-installer
 # --------------------------------------------------------------------------------------------
 
@@ -50,15 +50,11 @@ variable "custom_agent_image_tag" {
 variable "production_type" {
   default     = null
   type        = string
-  description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Leave it `null` when you want Terraform Enterprise to use its own default."
+  description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, `active-active` or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Close `active-active` when deploying more than 1 node. Leave it `null` when you want Terraform Enterprise to use its own default."
 
   validation {
-    condition = (
-      var.production_type == "external" ||
-      var.production_type == "disk" ||
-      var.production_type == null
-    )
-    error_message = "The production_type must be 'external', 'disk', or omitted."
+    condition     = contains(["external", "disk", "active-active", null], var.production_type, "The production_type must be 'external', 'disk', or omitted.")
+    error_message = "The production_type must be 'external', 'disk', `active-active`, or omitted."
   }
 }
 
@@ -157,12 +153,6 @@ variable "bypass_preflight_checks" {
   description = "Allow the TFE application to start without preflight checks; defaults to false."
 }
 
-variable "enable_active_active" {
-  default     = false
-  type        = bool
-  description = "True if TFE running in active-active configuration, which requires an external Redis server. Defaults to false."
-}
-
 variable "hostname" {
   default     = null
   type        = string
@@ -222,25 +212,25 @@ variable "tls_bootstrap_key_pathname" {
 variable "pg_user" {
   default     = null
   type        = string
-  description = "(Required when production_type is 'external') PostgreSQL user to connect as."
+  description = "(Required when production_type is 'external' or 'active-active') PostgreSQL user to connect as."
 }
 
 variable "pg_password" {
   default     = null
   type        = string
-  description = "(Required when production_type is 'external') The password for the PostgreSQL user."
+  description = "(Required when production_type is 'external' or 'active-active') The password for the PostgreSQL user."
 }
 
 variable "pg_netloc" {
   default     = null
   type        = string
-  description = "(Required when production_type is 'external') The hostname and port of the target PostgreSQL server, in the format hostname:port."
+  description = "(Required when production_type is 'external' or 'active-active') The hostname and port of the target PostgreSQL server, in the format hostname:port."
 }
 
 variable "pg_dbname" {
   default     = null
   type        = string
-  description = "(Required when production_type is 'external') The database name"
+  description = "(Required when production_type is 'external' or 'active-active') The database name"
 }
 
 variable "pg_extra_params" {
@@ -255,7 +245,7 @@ variable "pg_extra_params" {
 variable "redis_host" {
   default     = null
   type        = string
-  description = "(Required when enable_active_active is true) Hostname of an external Redis instance which is resolvable from the TFE instance."
+  description = "(Required when production_type is 'active-active') Hostname of an external Redis instance which is resolvable from the TFE instance."
 }
 
 variable "redis_pass" {


### PR DESCRIPTION
## Background

It seems that the logic of the `active-active` production type is:

a) Different than the other operational modes
b) Too-complicated

This PR makes `active-active` consistent with the other operational modes.