### PR TITLE
remove retry for docker install commands

### DIFF
--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -168,9 +168,9 @@ echo \
 	"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
 	https://download.docker.com/linux/ubuntu $(lsb_release --codename --short) stable" \
 	| sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-retry 10 apt-get --assume-yes update
-retry 10 apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
-retry 10 apt-get --assume-yes autoremove
+apt-get --assume-yes update
+apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
+apt-get --assume-yes autoremove
 %{ endif ~}
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Installing TFE FDO" | tee -a $log_pathname

--- a/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
+++ b/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
@@ -212,8 +212,8 @@ echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootst
 	yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 	yum install --assumeyes docker-ce docker-ce-cli containerd.io
 	%{ else ~}
-	retry 10 apt-get --assume-yes update
-	retry 10 apt-get --assume-yes install \
+	apt-get --assume-yes update
+	apt-get --assume-yes install \
 		ca-certificates \
 		curl \
 		gnupg \
@@ -224,9 +224,9 @@ echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootst
 		"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
 		https://download.docker.com/linux/ubuntu $(lsb_release --codename --short) stable" \
 		| sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-	retry 10 apt-get --assume-yes update
-	retry 10 apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
-	retrt 10 apt-get --assume-yes autoremove
+	apt-get --assume-yes update
+	apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
+	apt-get --assume-yes autoremove
 	%{ endif ~}
 
 replicated_filename="replicated.tar.gz"


### PR DESCRIPTION
## Background

Removing retries for apt commands installing docker. This is not required as we have increased retries for unzip command.