### PR TITLE
Install the bc package on amazon linux

### DIFF
--- a/modules/tfe_init_replicated/templates/install_packages.func
+++ b/modules/tfe_init_replicated/templates/install_packages.func
@@ -18,7 +18,7 @@ function install_packages {
 			echo "[$(date +"%FT%T")] [Terraform Enterprise] Remove existing docker and install v24 with yum" | tee -a $log_pathname
 			yum -y remove docker
 			yum clean packages
-			yum -y install docker-24.0.5-1.amzn2023.0.3
+			yum -y install docker-24.0.5-1.amzn2023.0.3 bc
 
 			systemctl start docker
 			systemctl enable docker


### PR DESCRIPTION
## Background
seeing an error in cloud init on amazon linux 2023 `/var/lib/cloud/instance/scripts/part-001: line 210: bc: command not found` so I'm adding the bc package to the install command.

Relates OR Closes #0000

## How has this been tested?

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
