### PR TITLE
Optionally enable exec capabilities in /run (Docker)

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -59,7 +59,7 @@ locals {
         read_only = true
         tmpfs = [
           "/tmp:mode=01777",
-          "/run",
+          "/run:${var.enable_run_exec_tmpfs ? "exec" : "noexec"}",
           "/var/log/terraform-enterprise",
         ]
         ports = flatten([

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -348,3 +348,9 @@ variable "vault_token_renew" {
   type        = number
   description = "Vault token renewal period in seconds. Required when TFE_VAULT_USE_EXTERNAL is true."
 }
+
+variable "enable_run_exec_tmpfs" {
+  default     = false
+  type        = bool
+  description = "Enable the use of executables in the tmpfs for the /run directory. Defaults to false."
+}


### PR DESCRIPTION
## Background

When I was trying to understand why the issue with Aurora failovers is **not** related to DNS caching I had to make use of several diagnostics tools that we don't install in the container or the host for security reasons i.e. `dig`, `nc`, `vim`, etc.

This was not possible because of the way the compose file was set up. I had to modify the `/etc/tfe/compose to achieve this.yaml` file in the host machine and restart the container. This is annoying.

I figured that this would be useful for future scenarios
