### PR TITLE
Fix https proxy address for apt

### DIFF
--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -34,7 +34,7 @@ EOF
 
 /bin/cat <<EOF >/etc/apt/apt.conf
 Acquire::http::Proxy "http://${proxy_ip}:${proxy_port}";
-Acquire::https::Proxy "https://${proxy_ip}:${proxy_port}";
+Acquire::https::Proxy "http://${proxy_ip}:${proxy_port}";
 EOF
 
 export http_proxy="${proxy_ip}:${proxy_port}"

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -33,7 +33,7 @@ EOF
 
 /bin/cat <<EOF >/etc/apt/apt.conf
 Acquire::http::Proxy "http://${proxy_ip}:${proxy_port}";
-Acquire::https::Proxy "https://${proxy_ip}:${proxy_port}";
+Acquire::https::Proxy "http://${proxy_ip}:${proxy_port}";
 EOF
 
 export http_proxy="${proxy_ip}:${proxy_port}"

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -47,7 +47,7 @@ EOF
 
 /bin/cat <<EOF >/etc/apt/apt.conf
 Acquire::http::Proxy "http://${proxy_ip}:${proxy_port}";
-Acquire::https::Proxy "https://${proxy_ip}:${proxy_port}";
+Acquire::https::Proxy "http://${proxy_ip}:${proxy_port}";
 EOF
 
 export http_proxy="${proxy_ip}:${proxy_port}"

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -50,7 +50,7 @@ EOF
 
 /bin/cat <<EOF >/etc/apt/apt.conf
 Acquire::http::Proxy "http://${proxy_ip}:${proxy_port}";
-Acquire::https::Proxy "https://${proxy_ip}:${proxy_port}";
+Acquire::https::Proxy "http://${proxy_ip}:${proxy_port}";
 EOF
 
 export http_proxy="${proxy_ip}:${proxy_port}"


### PR DESCRIPTION
## Background

This PR fixes the https proxy address for apt. 
The address should have `http` instead of `https`. This was added by mistake in previous [PR](https://github.com/hashicorp/terraform-random-tfe-utility/pull/168)

## How has this been tested?
End to end test scenario of TFE behind proxy.


### Did you add a new setting?
No

