### PR TITLE
Tf-24345 :: sentinel support

### DIFF
--- a/modules/runtime_container_engine_config/redis_config.tf
+++ b/modules/runtime_container_engine_config/redis_config.tf
@@ -3,11 +3,16 @@
 
 locals {
   redis = {
-    TFE_REDIS_HOST     = var.redis_use_tls != null ? var.redis_use_tls ? "${var.redis_host}:6380" : var.redis_host : null
-    TFE_REDIS_USER     = var.redis_user
-    TFE_REDIS_PASSWORD = var.redis_password
-    TFE_REDIS_USE_TLS  = var.redis_use_tls
-    TFE_REDIS_USE_AUTH = var.redis_use_auth
+    TFE_REDIS_HOST                 = var.redis_use_tls != null ? var.redis_use_tls ? "${var.redis_host}:6380" : var.redis_host : null
+    TFE_REDIS_USER                 = var.redis_user
+    TFE_REDIS_PASSWORD             = var.redis_password
+    TFE_REDIS_USE_TLS              = var.redis_use_tls
+    TFE_REDIS_USE_AUTH             = var.redis_use_auth
+    TFE_REDIS_SENTINEL_ENABLED     = var.redis_use_sentinel
+    TFE_REDIS_SENTINEL_HOSTS       = join(var.redis_sentinel_hosts, ",")
+    TFE_REDIS_SENTINEL_LEADER_NAME = var.redis_sentinel_leader_name
+    TFE_REDIS_SENTINEL_PASSWORD    = var.redis_sentinel_password
+    TFE_REDIS_SENTINEL_USERNAME    = var.redis_sentinel_user
   }
   redis_configuration = local.active_active ? local.redis : {}
 }

--- a/modules/runtime_container_engine_config/redis_config.tf
+++ b/modules/runtime_container_engine_config/redis_config.tf
@@ -9,7 +9,7 @@ locals {
     TFE_REDIS_USE_TLS              = var.redis_use_tls
     TFE_REDIS_USE_AUTH             = var.redis_use_auth
     TFE_REDIS_SENTINEL_ENABLED     = var.redis_use_sentinel
-    TFE_REDIS_SENTINEL_HOSTS       = join(var.redis_sentinel_hosts, ",")
+    TFE_REDIS_SENTINEL_HOSTS       = join(",", var.redis_sentinel_hosts)
     TFE_REDIS_SENTINEL_LEADER_NAME = var.redis_sentinel_leader_name
     TFE_REDIS_SENTINEL_PASSWORD    = var.redis_sentinel_password
     TFE_REDIS_SENTINEL_USERNAME    = var.redis_sentinel_user

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -229,16 +229,19 @@ variable "redis_sentinel_hosts" {
 variable "redis_sentinel_leader_name" {
   type        = string
   description = "The name of the sentinel leader."
+  default     = null
 }
 
 variable "redis_sentinel_user" {
   type        = string
   description = "Redis sentinel user. Leave blank to not use a user when authenticating to redis sentinel. Defaults to \"\" if no value is given."
+  default = null
 }
 
 variable "redis_sentinel_password" {
   type        = string
   description = "Redis senitnel password."
+  default = null
 }
 
 variable "run_pipeline_image" {

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -214,6 +214,33 @@ variable "redis_user" {
   description = "Redis server user. Leave blank to not use a user when authenticating. Defaults to \"\" if no value is given."
 }
 
+variable "redis_use_sentinel" {
+  type        = bool
+  description = "Will connections to redis use the sentinel protocol?"
+  default     = false
+}
+
+variable "redis_sentinel_hosts" {
+  type        = array(string)
+  description = "A list of sentinel host/port combinations in the form of 'host:port', eg: sentinel-leader.terraform.io:26379"
+  default     = []
+}
+
+variable "redis_sentinel_leader_name" {
+  type        = string
+  description = "The name of the sentinel leader."
+}
+
+variable "redis_sentinel_user" {
+  type        = string
+  description = "Redis sentinel user. Leave blank to not use a user when authenticating to redis sentinel. Defaults to \"\" if no value is given."
+}
+
+variable "redis_sentinel_password" {
+  type        = string
+  description = "Redis senitnel password."
+}
+
 variable "run_pipeline_image" {
   type        = string
   description = "Container image used to execute Terraform runs. Leave blank to use the default image that comes with Terraform Enterprise. Defaults to \"\" if no value is given."

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -235,13 +235,13 @@ variable "redis_sentinel_leader_name" {
 variable "redis_sentinel_user" {
   type        = string
   description = "Redis sentinel user. Leave blank to not use a user when authenticating to redis sentinel. Defaults to \"\" if no value is given."
-  default = null
+  default     = null
 }
 
 variable "redis_sentinel_password" {
   type        = string
   description = "Redis senitnel password."
-  default = null
+  default     = null
 }
 
 variable "run_pipeline_image" {

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -221,7 +221,7 @@ variable "redis_use_sentinel" {
 }
 
 variable "redis_sentinel_hosts" {
-  type        = array(string)
+  type        = list(string)
   description = "A list of sentinel host/port combinations in the form of 'host:port', eg: sentinel-leader.terraform.io:26379"
   default     = []
 }


### PR DESCRIPTION
## Background

This change allows for the usage of Redis Sentinel in the terraform enterprise init templating.

## How has this been tested?

significant direct testing in development environments

### Did you add a new setting?

yes, but they are defaulted and consumed internally.

## This PR makes me feel

<img src="https://media0.giphy.com/media/okfvUCpgArv3y/giphy.gif?cid=bd3ea57el3jyukp1wqu4bl5g6pgm1rzj4rs199m21z087qzg&ep=v1_gifs_trending&rid=giphy.gif&ct=g"/>
