### PR TITLE
Add arm64 support for downloaded tools, upgrade jq 1.7.1

### DIFF
--- a/fixtures/test_proxy_init/templates/install_packages.func
+++ b/fixtures/test_proxy_init/templates/install_packages.func
@@ -9,7 +9,7 @@ function install_packages {
 	apt-get install -y unzip
 
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install AWS CLI" | tee -a $log_pathname
-	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m | grep -q "arm\|aarch" && echo "aarch64" || echo "x86_64").zip" -o "awscliv2.zip"
 	unzip awscliv2.zip
 	./aws/install
 	rm -f ./awscliv2.zip

--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -12,7 +12,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -13,7 +13,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -13,7 +13,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -12,7 +12,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -12,7 +12,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -12,7 +12,7 @@ log_pathname="/var/log/startup.log"
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if proxy_ip != null ~}

--- a/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
@@ -10,7 +10,7 @@ ${install_monitoring_agents}
 log_pathname="/var/log/startup.log"
 
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 
@@ -18,7 +18,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 docker_directory="/etc/docker"

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -10,7 +10,7 @@ ${install_monitoring_agents}
 log_pathname="/var/log/startup.log"
 
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 
@@ -18,7 +18,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 docker_directory="/etc/docker"

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -11,7 +11,7 @@ log_pathname="/var/log/startup.log"
 
 %{ if distribution == "rhel" ~}
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
@@ -19,7 +19,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 docker_directory="/etc/docker"

--- a/modules/tfe_init/templates/install_packages.func
+++ b/modules/tfe_init/templates/install_packages.func
@@ -21,7 +21,7 @@ function install_packages {
 	%{ endif ~}
 
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install AWS CLI" | tee -a $log_pathname
-	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m | grep -q "arm\|aarch" && echo "aarch64" || echo "x86_64").zip" -o "awscliv2.zip"
 	unzip awscliv2.zip
 	./aws/install
 	rm -f ./awscliv2.zip

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -12,7 +12,7 @@ log_pathname="/var/log/startup.log"
 
 %{ if cloud == "google" && distribution == "rhel" ~}
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
@@ -20,7 +20,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ if cloud == "google" ~}

--- a/modules/tfe_init_replicated/templates/install_packages.func
+++ b/modules/tfe_init_replicated/templates/install_packages.func
@@ -39,7 +39,7 @@ function install_packages {
 	%{ endif ~}
 
 	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install AWS CLI" | tee -a $log_pathname
-	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+	curl --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m | grep -q "arm\|aarch" && echo "aarch64" || echo "x86_64").zip" -o "awscliv2.zip"
 	unzip awscliv2.zip
 	./aws/install
 	rm -f ./awscliv2.zip

--- a/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
+++ b/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
@@ -15,7 +15,7 @@ tfe_settings_path="/etc/$tfe_settings_file"
 # -----------------------------------------------------------------------------
 %{ if cloud == "google" && distribution == "rhel" ~}
 echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_pathname
-# workaround for GCP RHEL 7 known issue 
+# workaround for GCP RHEL 7 known issue
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
@@ -27,7 +27,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 install_packages $log_pathname
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
 sudo chmod +x /bin/jq
 
 %{ endif ~}


### PR DESCRIPTION
## Background

To support the TFE on ARM beta I wanted to deploy https://github.com/hashicorp/terraform-aws-terraform-enterprise but with an arm AMI and ec2 instance. Unfortunately in our start up scripts here we have everything pinned to x86/amd64 binaries. 

So I needed to update those bits to go download the appropriate binary for the architecture being used. For this I just detected it in a one-liner using `uname`. 

## How has this been tested?

Used the `terraform-aws-terraform-enterprise` module above with the settings: 

```
  instance_type         = "m6g.xlarge"
  ami_id                = "ami-0e8c824f386e1de06"
```

to get an ARM instance running an ARM version of Ubuntu. Then did the normal manual release tests. 

## This PR makes me feel

![two people from Dethklok Metalacolypse grasping hands in that "hard style" way or in that "I just accepted a mission and awww yeah it's on" sort of way from 80s action films](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHl0d2NvbWNqNG9ocnU5NW5kcGEyMWV3bjBpa20wdnJ1MnE1bHI4ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/63e1tyVx9ad1Vf6TjI/giphy.gif)
