### PR TITLE
Add support for configuring Admin API HTTPS

### DIFF
--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -66,6 +66,7 @@ locals {
         ports = flatten([
           "80:${var.http_port}",
           "443:${var.https_port}",
+          "8443:${var.admin_api_https_port}",
           local.active_active ? ["8201:8201"] : [],
           var.metrics_endpoint_enabled ? [
             "${var.metrics_endpoint_port_http}:9090",
@@ -130,6 +131,10 @@ locals {
           {
             containerPort = var.https_port
             hostPort      = 443
+          },
+          {
+            containerPort = var.admin_api_https_port
+            hostPort      = 8443
           },
           local.active_active ? [{ containerPort = 8201, hostPort = 8201 }] : [],
           var.metrics_endpoint_enabled ? [

--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -66,7 +66,7 @@ locals {
         ports = flatten([
           "80:${var.http_port}",
           "443:${var.https_port}",
-          "8443:${var.admin_api_https_port}",
+          "${var.admin_api_https_port}:${var.admin_api_https_port}",
           local.active_active ? ["8201:8201"] : [],
           var.metrics_endpoint_enabled ? [
             "${var.metrics_endpoint_port_http}:9090",
@@ -134,7 +134,7 @@ locals {
           },
           {
             containerPort = var.admin_api_https_port
-            hostPort      = 8443
+            hostPort      = var.admin_api_https_port
           },
           local.active_active ? [{ containerPort = 8201, hostPort = 8201 }] : [],
           var.metrics_endpoint_enabled ? [

--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -20,6 +20,7 @@ locals {
       TFE_HOSTNAME                  = var.hostname
       TFE_HTTP_PORT                 = var.http_port
       TFE_HTTPS_PORT                = var.https_port
+      TFE_ADMIN_HTTPS_PORT          = var.admin_api_https_port
       TFE_OPERATIONAL_MODE          = var.operational_mode
       TFE_ENCRYPTION_PASSWORD       = random_password.enc_password.result
       TFE_DISK_CACHE_VOLUME_NAME    = "terraform-enterprise_terraform-enterprise-cache"

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -88,6 +88,12 @@ variable "https_port" {
   description = "Port application listens on for HTTPS. Default is 443."
 }
 
+variable "admin_api_https_port" {
+  default     = null
+  type        = number
+  description = "Port application listens on for Admin API. Default is 8443."
+}
+
 variable "iact_subnets" {
   type        = string
   description = "Comma-separated list of subnets in CIDR notation that are allowed to retrieve the initial admin creation token via the API (e.g. 10.0.0.0/8,192.168.0.0/24). Leave blank to disable retrieving the initial admin creation token via the API from outside the host. Defaults to \"\" if no value is given."

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -89,9 +89,9 @@ variable "https_port" {
 }
 
 variable "admin_api_https_port" {
-  default     = null
+  default     = 8443
   type        = number
-  description = "Port application listens on for Admin API."
+  description = "Port application listens on for Admin API. Default is 8443."
 }
 
 variable "iact_subnets" {

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -91,7 +91,7 @@ variable "https_port" {
 variable "admin_api_https_port" {
   default     = null
   type        = number
-  description = "Port application listens on for Admin API. Default is 8443."
+  description = "Port application listens on for Admin API."
 }
 
 variable "iact_subnets" {


### PR DESCRIPTION
## Background
[Jira](https://hashicorp.atlassian.net/browse/TF-26458)

This pull request introduces support for configuring an Admin API HTTPS port in the Terraform Enterprise runtime container engine configuration. The changes include adding a new variable for the port and updating the relevant configurations to support this feature.

## How has this been tested?
Via https://github.com/hashicorp/ptfedev-infra/pull/815. I used it to validate access to the admin API.

