### PR TITLE
Tauhid621 azure msi

### DIFF
--- a/modules/runtime_container_engine_config/database_config.tf
+++ b/modules/runtime_container_engine_config/database_config.tf
@@ -3,11 +3,13 @@
 
 locals {
   database = {
-    TFE_DATABASE_USER       = var.database_user
-    TFE_DATABASE_PASSWORD   = var.database_password
-    TFE_DATABASE_HOST       = var.database_host
-    TFE_DATABASE_NAME       = var.database_name
-    TFE_DATABASE_PARAMETERS = var.database_parameters
+    TFE_DATABASE_USER                         = var.database_user
+    TFE_DATABASE_PASSWORD                     = var.database_password
+    TFE_DATABASE_HOST                         = var.database_host
+    TFE_DATABASE_NAME                         = var.database_name
+    TFE_DATABASE_PARAMETERS                   = var.database_parameters
+    TFE_DATABASE_PASSWORDLESS_AZURE_USE_MSI   = var.database_passwordless_azure_use_msi
+    TFE_DATABASE_PASSWORDLESS_AZURE_CLIENT_ID = var.database_passwordless_azure_client_id
   }
   database_configuration = local.disk ? {} : local.database
 }

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -70,6 +70,18 @@ variable "database_user" {
   description = "PostgreSQL user. Required when TFE_OPERATIONAL_MODE is external or active-active."
 }
 
+variable "database_passwordless_azure_use_msi" {
+  default     = false
+  type        = bool
+  description = "Whether or not to use Azure Managed Service Identity (MSI) to connect to the PostgreSQL database. Defaults to false if no value is given."
+}
+
+variable "database_passwordless_azure_client_id" {
+  default     = ""
+  type        = string
+  description = "Azure Managed Service Identity (MSI) Client ID. If not set, System Assigned Managed Identity will be used."
+}
+
 variable "disk_path" {
   default     = null
   description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode. Required when var.operational_mode is 'disk'."

--- a/modules/tfe_init/functions.tf
+++ b/modules/tfe_init/functions.tf
@@ -22,4 +22,13 @@ locals {
   retry = templatefile("${path.module}/templates/retry.func", {
     cloud = var.cloud
   })
+
+  azurerm_database_init = templatefile("${path.module}/templates/azurerm_database_init.func.tpl", {
+    distribution            = var.distribution
+    msi_auth_enabled        = var.database_passwordless_azure_use_msi
+    database_host           = var.database_host
+    database_name           = var.database_name
+    admin_database_username = var.admin_database_username
+    admin_database_password = var.admin_database_password
+  })
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -53,6 +53,7 @@ locals {
       install_monitoring_agents = local.install_monitoring_agents
       retry                     = local.retry
       quadlet_unit              = local.quadlet_unit
+      azurerm_database_init     = local.azurerm_database_init
 
       active_active               = var.operational_mode == "active-active"
       cloud                       = var.cloud
@@ -81,6 +82,8 @@ locals {
       redis_bootstrap_cert_pathname = local.redis_bootstrap_cert_pathname
       redis_bootstrap_key_pathname  = local.redis_bootstrap_key_pathname
       redis_bootstrap_ca_pathname   = local.redis_bootstrap_ca_pathname
+
+      database_azure_msi_auth_enabled   = var.database_passwordless_azure_use_msi
 
       proxy_ip   = var.proxy_ip
       proxy_port = var.proxy_port

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -6,6 +6,9 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+%{ if database_azure_msi_auth_enabled ~}
+${azurerm_database_init}
+%{ endif ~}
 
 log_pathname="/var/log/startup.log"
 
@@ -111,6 +114,10 @@ echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard
 
 %{ if enable_monitoring ~}
 install_monitoring_agents $log_pathname
+%{ endif ~}
+
+%{ if database_azure_msi_auth_enabled ~}
+azurerm_database_init $log_pathname
 %{ endif ~}
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Installing Docker Engine from Repository" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -6,6 +6,9 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+%{ if database_azure_msi_auth_enabled ~}
+${azurerm_database_init}
+%{ endif ~}
 
 log_pathname="/var/log/startup.log"
 
@@ -111,6 +114,10 @@ echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard
 
 %{ if enable_monitoring ~}
 install_monitoring_agents $log_pathname
+%{ endif ~}
+
+%{ if database_azure_msi_auth_enabled ~}
+azurerm_database_init $log_pathname
 %{ endif ~}
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Installing Podman" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -6,6 +6,9 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+%{ if database_azure_msi_auth_enabled ~}
+${azurerm_database_init}
+%{ endif ~}
 
 log_pathname="/var/log/startup.log"
 
@@ -102,6 +105,10 @@ echo "UUID=$(lsblk --noheadings --output uuid $device) ${disk_path} ext4 discard
 
 %{ if enable_monitoring ~}
 install_monitoring_agents $log_pathname
+%{ endif ~}
+
+%{ if database_azure_msi_auth_enabled ~}
+azurerm_database_init $log_pathname
 %{ endif ~}
 
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Installing Docker Engine from Repository" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm_database_init.func.tpl
+++ b/modules/tfe_init/templates/azurerm_database_init.func.tpl
@@ -1,0 +1,30 @@
+%{ if msi_auth_enabled ~}
+function azurerm_database_init {
+	local log_pathname=$1
+
+	%{ if distribution == "ubuntu" ~}
+	apt-get --assume-yes update
+	apt-get --assume-yes install postgresql-client
+	%{ else ~}
+	yum install --assumeyes postgresql
+	%{ endif ~}
+
+	# Database connection parameters
+	DB_HOST="${database_host}"
+	DB_PORT="5432"
+	DB_NAME="postgres"
+	DB_USER="${admin_database_username}"
+	DB_PASSWORD="${admin_database_password}"
+
+	# SQL command to execute
+	SQL_COMMAND="ALTER DATABASE ${database_name} OWNER TO azure_pg_admin;"
+
+	echo "[Terraform Enterprise] Changing owner of database '${database_name}' to 'azure_pg_admin'." | tee -a $log_pathname
+
+	if PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "$SQL_COMMAND"; then
+        echo "[Terraform Enterprise] Successfully changed database owner." | tee -a $log_pathname
+    else
+        echo "[Terraform Enterprise] ERROR: Failed to change database owner." | tee -a $log_pathname
+    fi
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/azurerm_database_init.func.tpl
+++ b/modules/tfe_init/templates/azurerm_database_init.func.tpl
@@ -1,4 +1,7 @@
 %{ if msi_auth_enabled ~}
+
+# Updates the owner of database to `azure_pg_admin` so that 
+# MSI identity user can perform operations in the database
 function azurerm_database_init {
 	local log_pathname=$1
 
@@ -22,9 +25,9 @@ function azurerm_database_init {
 	echo "[Terraform Enterprise] Changing owner of database '${database_name}' to 'azure_pg_admin'." | tee -a $log_pathname
 
 	if PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "$SQL_COMMAND"; then
-        echo "[Terraform Enterprise] Successfully changed database owner." | tee -a $log_pathname
-    else
-        echo "[Terraform Enterprise] ERROR: Failed to change database owner." | tee -a $log_pathname
+		echo "[Terraform Enterprise] Successfully changed database owner." | tee -a $log_pathname
+	else
+		echo "[Terraform Enterprise] ERROR: Failed to change database owner." | tee -a $log_pathname
     fi
 }
 %{ endif ~}

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -160,21 +160,25 @@ variable "tfe_image" {
 
 ### Database details
 variable "database_host" {
+  default     = null
   type        = string
   description = "The PostgreSQL server to connect to. Required when Azure PostgreSQL MSI auth is enabled"
 }
 
 variable "database_name" {
+  default     = null
   type        = string
   description = "Name of the PostgreSQL database to store application data in."
 }
 
 variable "admin_database_username" {
+  default     = null
   type        = string
   description = "PostgreSQL user."
 }
 
 variable "admin_database_password" {
+  default     = null
   type        = string
   description = "PostgreSQL password."
 }

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -157,3 +157,30 @@ variable "tfe_image" {
   type        = string
   description = "The registry path, image name, and image version (e.g. \"quay.io/hashicorp/terraform-enterprise:1234567\")"
 }
+
+### Database details
+variable "database_host" {
+  type        = string
+  description = "The PostgreSQL server to connect to. Required when Azure PostgreSQL MSI auth is enabled"
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database to store application data in."
+}
+
+variable "admin_database_username" {
+  type        = string
+  description = "PostgreSQL user."
+}
+
+variable "admin_database_password" {
+  type        = string
+  description = "PostgreSQL password."
+}
+
+variable "database_passwordless_azure_use_msi" {
+  default     = false
+  type        = bool
+  description = "Whether or not to use Azure Managed Service Identity (MSI) to connect to the PostgreSQL database. Defaults to false if no value is given."
+}


### PR DESCRIPTION
## Background

This PR adds configuration for using managed service authentication in Azure deployment.
- Adds configuration variable in `runtime_container_engine` module
- Adds a function in `tfe_init` module to change owner of the databse to `azure_pg_admin`. This ensures that the msi identity has access over the database

## How has this been tested?
Tested against `tauhid621_azure_msi` [branch](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/compare/main...tauhid621_azure_msi) in [terraform-azurerm-terraform-enterprise](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise). TFE was up and running.

## TFE Modules

### Did you add a new setting?
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise) : Draft [PR](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/262)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
