### PR TITLE
add support for Redis Sentinel

### DIFF
--- a/modules/settings/tfe_redis_config.tf
+++ b/modules/settings/tfe_redis_config.tf
@@ -26,7 +26,7 @@ locals {
     redis_use_mtls = {
       value = var.redis_use_mtls != null ? var.redis_use_mtls ? "1" : "0" : null
     }
-    
+
     redis_use_sentinel = {
       value = var.redis_use_sentinel != null ? var.redis_use_sentinel ? "1" : "0" : null
     }

--- a/modules/settings/tfe_redis_config.tf
+++ b/modules/settings/tfe_redis_config.tf
@@ -26,6 +26,11 @@ locals {
     redis_use_mtls = {
       value = var.redis_use_mtls != null ? var.redis_use_mtls ? "1" : "0" : null
     }
+    
+    redis_use_sentinel = {
+      value = var.redis_use_sentinel != null ? var.redis_use_sentinel ? "1" : "0" : null
+    }
+
   }
 
   redis_configuration = var.production_type == "active-active" ? local.redis_configs : {}

--- a/modules/settings/variables.tf
+++ b/modules/settings/variables.tf
@@ -272,6 +272,13 @@ variable "redis_use_mtls" {
   description = "Redis service requires mutual TLS authentication. If true, the external Redis instance will use TLS certs for authentication."
 }
 
+variable "redis_use_sentinel" {
+  default     = null
+  type        = bool
+  description = "Redis service uses Sentinel."
+}
+
+
 # ------------------------------------------------------
 # Mounted Disk
 # ------------------------------------------------------

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -88,6 +88,14 @@ locals {
       redis_certificate_secret_id    = var.redis_client_certificate_secret_id
       redis_client_key_secret_id     = var.redis_client_key_secret_id
 
+      enable_redis_sentinel          = var.enable_redis_sentinel
+      redis_sentinel_hosts           = var.redis_sentinel_hosts
+      redis_sentinel_leader_name     = var.redis_sentinel_leader_name    
+      redis_sentinel_username        = var.redis_sentinel_username
+      redis_sentinel_password        = var.redis_sentinel_password
+
+      
+
       enable_postgres_mtls              = var.enable_postgres_mtls
       postgres_ca_certificate_secret_id = var.postgres_ca_certificate_secret_id
       postgres_certificate_secret_id    = var.postgres_client_certificate_secret_id

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -88,13 +88,13 @@ locals {
       redis_certificate_secret_id    = var.redis_client_certificate_secret_id
       redis_client_key_secret_id     = var.redis_client_key_secret_id
 
-      enable_redis_sentinel          = var.enable_redis_sentinel
-      redis_sentinel_hosts           = var.redis_sentinel_hosts
-      redis_sentinel_leader_name     = var.redis_sentinel_leader_name    
-      redis_sentinel_username        = var.redis_sentinel_username
-      redis_sentinel_password        = var.redis_sentinel_password
+      enable_redis_sentinel      = var.enable_redis_sentinel
+      redis_sentinel_hosts       = var.redis_sentinel_hosts
+      redis_sentinel_leader_name = var.redis_sentinel_leader_name
+      redis_sentinel_username    = var.redis_sentinel_username
+      redis_sentinel_password    = var.redis_sentinel_password
 
-      
+
 
       enable_postgres_mtls              = var.enable_postgres_mtls
       postgres_ca_certificate_secret_id = var.postgres_ca_certificate_secret_id

--- a/modules/tfe_init/variables.tf
+++ b/modules/tfe_init/variables.tf
@@ -7,6 +7,12 @@ variable "enable_redis_mtls" {
   description = "Should Redis mTLS be enabled? This requires the redis_ca_certificate_secret_id, redis_client_key_secret_id and redis_client_certificate_secret_id variables to be set."
 }
 
+variable "enable_redis_sentinel" {
+  default     = false
+  type        = bool
+  description = "Should Redis Sentinel be enabled? This requires the redis_sentinel_hosts, redis_sentinel_leader_name, redis_sentinel_username, and redis_sentinel_password variables to be set."
+}
+
 variable "enable_postgres_mtls" {
   default     = false
   type        = bool
@@ -42,6 +48,31 @@ variable "postgres_ca_certificate_secret_id" {
   type        = string
   description = "A secret ID which contains the Base64 encoded version of a PEM encoded public certificate of a certificate authority (CA) to be trusted by the database instance"
 }
+
+variable "redis_sentinel_hosts" {
+  default     = null
+  type        = list(string)
+  description = "hostnames of Redis Sentinel instances"
+}
+
+variable "redis_sentinel_leader_name" {
+  default     = null
+  type        = string
+  description = "the Sentinel instance that is elected to manage a failover when a master Redis instance becomes unavailable"
+}
+
+variable "redis_sentinel_username" {
+  default     = null
+  type        = string
+  description = "username to log into sentinel"
+}
+
+variable "redis_sentinel_password" {
+  default     = null
+  type        = string
+  description = "password to log into sentinel"
+}
+
 
 variable "postgres_client_certificate_secret_id" {
   default     = null


### PR DESCRIPTION
## Background

Adding support for Redis Sentinel.

Relates OR Closes #0000

## How has this been tested?

This is part of TFE release testing.

## TFE Modules

### Did you add a new setting?

yes. The changes were mostly already made in `terraform-aws-terraform-enterprise` though.

- [x] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)


Related:
https://github.com/hashicorp/ptfedev-infra/pull/831
https://github.com/hashicorp/terraform-enterprise/pull/2742
https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/362
## This PR makes me feel

![optional gif describing your feelings about this pr]()
