### PR TITLE
Adds a get_unmounted_disk function to aws startup scripts

### DIFF
--- a/modules/tfe_init/files/get_unmounted_disk.func
+++ b/modules/tfe_init/files/get_unmounted_disk.func
@@ -1,0 +1,33 @@
+# Function to get the name of an attached disk that does not have a mount point
+get_unmounted_disk() {
+    # Get all block devices
+    local all_devices=$(lsblk -rno NAME,TYPE,MOUNTPOINT)
+    
+    # Find all disks
+    echo "$all_devices" | while read -r name type mountpoint; do
+        if [[ "$type" == "disk" ]]; then
+            # Check if the disk itself is mounted or used as swap
+            if [[ -n "$mountpoint" ]] || swapon --show=NAME --noheadings | grep -q "^/dev/$name$"; then
+                continue
+            fi
+            
+            # Check if any partitions of this disk are mounted or used as swap
+            local has_mounted_partitions=false
+            while read -r part_name part_type part_mountpoint; do
+                # Check if this is a partition of the current disk
+                if [[ "$part_name" =~ ^${name}p?[0-9]+$ ]] && [[ "$part_type" == "part" ]]; then
+                    if [[ -n "$part_mountpoint" ]] || swapon --show=NAME --noheadings | grep -q "^/dev/$part_name$"; then
+                        has_mounted_partitions=true
+                        break
+                    fi
+                fi
+            done <<< "$all_devices"
+            
+            # If no partitions are mounted, this disk is available
+            if [[ "$has_mounted_partitions" == "false" ]]; then
+                echo "$name"
+                return 0
+            fi
+        fi
+    done
+}

--- a/modules/tfe_init/functions.tf
+++ b/modules/tfe_init/functions.tf
@@ -31,4 +31,5 @@ locals {
     admin_database_username = var.admin_database_username
     admin_database_password = var.admin_database_password
   })
+  get_unmounted_disk = file("${path.module}/templates/get_unmounted_disk.func")
 }

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -59,6 +59,7 @@ locals {
       retry                     = local.retry
       quadlet_unit              = local.quadlet_unit
       azurerm_database_init     = local.azurerm_database_init
+      get_unmounted_disk        = local.get_unmounted_disk
 
       active_active               = var.operational_mode == "active-active"
       cloud                       = var.cloud

--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -6,6 +6,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${get_unmounted_disk}
 
 log_pathname="/var/log/startup.log"
 
@@ -78,7 +79,7 @@ then
 fi
 
 %{ if disk_path != null ~}
-device="/dev/${disk_device_name}"
+device=/dev/$$(get_unmounted_disk)
 echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
 if lsblk --fs $device | grep ext4
 then

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -7,6 +7,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${get_unmounted_disk}
 
 log_pathname="/var/log/startup.log"
 
@@ -78,7 +79,7 @@ then
 fi
 
 %{ if disk_path != null ~}
-device="/dev/${disk_device_name}"
+device=/dev/$$(get_unmounted_disk)
 echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
 if lsblk --fs $device | grep ext4
 then

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -7,6 +7,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${get_unmounted_disk}
 
 log_pathname="/var/log/startup.log"
 
@@ -140,7 +141,7 @@ then
 fi
 
 %{ if disk_path != null ~}
-device="/dev/${disk_device_name}"
+device=/dev/$$(get_unmounted_disk)
 echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
 if lsblk --fs $device | grep ext4
 then


### PR DESCRIPTION

## Background

AWS instances with mounted disks have started randomly assigning the device name. This doesn't work with our modules proclivity to declare that device name statically before a plan / apply is done.  This change adds a function to determine which disk is not mounted itself, and does not have sub-partitions mounted.


## How has this been tested?
manual verification on an AWS EC2 instance running ubuntu

This needs to be tested on rhel.  After merge, if there are issues using the same function on rhel instances, a new change will be introduced to provide an os specific function.

## This PR makes me feel

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZXVxZTR5eWk0MHJmOGowN3lkcWtycXNzZGZ1aW1jOGN6NzJreTA0eiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/HUkOv6BNWc1HO/giphy.gif"/>
