### PR TITLE
Support explorer

### DIFF
--- a/modules/runtime_container_engine_config/database_config.tf
+++ b/modules/runtime_container_engine_config/database_config.tf
@@ -17,11 +17,11 @@ locals {
   }
   database_configuration = local.disk ? {} : local.database
   explorer_database = {
-    TFE_EXPLORER_DATABASE_HOST        = var.explorer_database_host
-    TFE_EXPLORER_DATABASE_NAME        = var.explorer_database_name
-    TFE_EXPLORER_DATABASE_USER        = var.explorer_database_user
-    TFE_EXPLORER_DATABASE_PASSWORD    = var.explorer_database_password
-    TFE_EXPLORER_DATABASE_PARAMETERS  = var.explorer_database_parameters
+    TFE_EXPLORER_DATABASE_HOST       = var.explorer_database_host
+    TFE_EXPLORER_DATABASE_NAME       = var.explorer_database_name
+    TFE_EXPLORER_DATABASE_USER       = var.explorer_database_user
+    TFE_EXPLORER_DATABASE_PASSWORD   = var.explorer_database_password
+    TFE_EXPLORER_DATABASE_PARAMETERS = var.explorer_database_parameters
   }
   explorer_database_configuration = var.explorer_database_host == null ? {} : local.explorer_database
 }

--- a/modules/runtime_container_engine_config/database_config.tf
+++ b/modules/runtime_container_engine_config/database_config.tf
@@ -16,4 +16,12 @@ locals {
     TFE_DATABASE_PASSWORDLESS_AZURE_CLIENT_ID = var.database_passwordless_azure_client_id
   }
   database_configuration = local.disk ? {} : local.database
+  explorer_database = {
+    TFE_EXPLORER_DATABASE_HOST        = var.explorer_database_host
+    TFE_EXPLORER_DATABASE_NAME        = var.explorer_database_name
+    TFE_EXPLORER_DATABASE_USER        = var.explorer_database_user
+    TFE_EXPLORER_DATABASE_PASSWORD    = var.explorer_database_password
+    TFE_EXPLORER_DATABASE_PARAMETERS  = var.explorer_database_parameters
+  }
+  explorer_database_configuration = var.explorer_database_host == null ? {} : local.explorer_database
 }

--- a/modules/runtime_container_engine_config/main.tf
+++ b/modules/runtime_container_engine_config/main.tf
@@ -10,6 +10,7 @@ locals {
     local.redis_configuration,
     local.storage_configuration,
     local.vault_configuration,
+    local.explorer_database_configuration,
     {
       http_proxy                    = var.http_proxy != null ? "http://${var.http_proxy}" : null
       HTTP_PROXY                    = var.http_proxy != null ? "http://${var.http_proxy}" : null

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -106,6 +106,31 @@ variable "database_passwordless_azure_client_id" {
   description = "Azure Managed Service Identity (MSI) Client ID. If not set, System Assigned Managed Identity will be used."
 }
 
+variable "explorer_database_host" {
+  type        = string
+  description = "The PostgreSQL server to connect to in the format HOST[:PORT] (e.g. db.example.com or db.example.com:5432). If only HOST is provided then the :PORT defaults to :5432 if no value is given. Required when TFE_OPERATIONAL_MODE is external or active-active."
+}
+
+variable "explorer_database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database to store application data in. Required when TFE_OPERATIONAL_MODE is external or active-active."
+}
+
+variable "explorer_database_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the connection URI. Used to configure the PostgreSQL connection (e.g. sslmode=require)."
+}
+
+variable "explorer_database_password" {
+  type        = string
+  description = "PostgreSQL password. Required when TFE_OPERATIONAL_MODE is external or active-active."
+}
+
+variable "explorer_database_user" {
+  type        = string
+  description = "PostgreSQL user. Required when TFE_OPERATIONAL_MODE is external or active-active."
+}
+
 variable "disk_path" {
   default     = null
   description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode. Required when var.operational_mode is 'disk'."


### PR DESCRIPTION
## Background

Please include a one or two sentence description of what you're changing and why.
This extends the runtime_container_engine_config module to support explorer config.

Relates OR Closes [TF-27485](https://hashicorp.atlassian.net/browse/TF-27485)

## How has this been tested?
in progress

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()


[TF-27485]: https://hashicorp.atlassian.net/browse/TF-27485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ