### PR TITLE
Adding default null options for explorer settings

### DIFF
--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -108,6 +108,7 @@ variable "database_passwordless_azure_client_id" {
 
 variable "explorer_database_host" {
   type        = string
+  default     = null
   description = "The PostgreSQL server to connect to in the format HOST[:PORT] (e.g. db.example.com or db.example.com:5432). If only HOST is provided then the :PORT defaults to :5432 if no value is given. Required when TFE_OPERATIONAL_MODE is external or active-active."
 }
 


### PR DESCRIPTION
## Background

#180  introduces a bug to non-aws-non-explorer cases where values for these variables are required to be provided, but are considered optional.  This change introduces null defaults to avoid this.

## How has this been tested?
terraform validate

## This PR makes me feel

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNzdqcnB0Z29ubTR5c3hidGtma2hpYm9iMzU5YWRhd2djYTN4NzR1aiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/wVTqRrtugMwyTZnIpX/giphy.gif"/>
