### PR TITLE
using single quotes for handling special characters

### DIFF
--- a/modules/tfe_init/templates/azurerm_database_init.func.tpl
+++ b/modules/tfe_init/templates/azurerm_database_init.func.tpl
@@ -13,11 +13,11 @@ function azurerm_database_init {
 	%{ endif ~}
 
 	# Database connection parameters
-	DB_HOST="${database_host}"
+	DB_HOST='${database_host}'
 	DB_PORT="5432"
 	DEFAULT_DATABASE="postgres"
-	DB_USER="${admin_database_username}"
-	DB_PASSWORD="${admin_database_password}"
+	DB_USER='${admin_database_username}'
+	DB_PASSWORD='${admin_database_password}'
 
 	# SQL command to execute
 	SQL_COMMAND="ALTER DATABASE ${database_name} OWNER TO azure_pg_admin;"


### PR DESCRIPTION
## Background

This PR adds support to provide special characters in database variable for `tfe_init` module.

We fix this by using single quotes instead of double quotes when the variable is assigned.

## How has this been tested?
Deployed TFE locally which was failing earlier due to `$` in the password.

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
