### PR TITLE
Fixing cloud-init script for EC2 in mounted-disk mode

### DIFF
--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -79,7 +79,7 @@ then
 fi
 
 %{ if disk_path != null ~}
-device=/dev/$$(get_unmounted_disk)
+device=/dev/$(get_unmounted_disk)
 echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
 if lsblk --fs $device | grep ext4
 then

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -141,7 +141,7 @@ then
 fi
 
 %{ if disk_path != null ~}
-device=/dev/$$(get_unmounted_disk)
+device=/dev/$(get_unmounted_disk)
 echo "[Terraform Enterprise] Checking disk at '$device' for EXT4 filesystem" | tee -a $log_pathname
 if lsblk --fs $device | grep ext4
 then


### PR DESCRIPTION
All mounted disks release tests were [failing](https://github.com/hashicorp/terraform-enterprise/actions/runs/16630838474/job/47664611096) due to a bug in cloud init script of EC2.
This PR fixes that.

<img width="999" height="884" alt="image" src="https://github.com/user-attachments/assets/9a9c9aab-8bfe-4f44-b5fe-f1923fd48685" />
