### PR TITLE
TF-28032 - JQ install in TFE modules is stable

### DIFF
--- a/modules/tfe_init/functions.tf
+++ b/modules/tfe_init/functions.tf
@@ -11,6 +11,10 @@ locals {
     distribution = var.distribution
   })
 
+  install_jq = templatefile("${path.module}/templates/install_jq.func", {
+    distribution = var.distribution
+  })
+
   install_monitoring_agents = templatefile("${path.module}/templates/install_monitoring_agents.func", {
     cloud             = var.cloud
     distribution      = var.distribution

--- a/modules/tfe_init/main.tf
+++ b/modules/tfe_init/main.tf
@@ -55,6 +55,7 @@ locals {
     {
       get_base64_secrets        = local.get_base64_secrets
       install_packages          = local.install_packages
+      install_jq                = local.install_jq
       install_monitoring_agents = local.install_monitoring_agents
       retry                     = local.retry
       quadlet_unit              = local.quadlet_unit

--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -7,14 +7,12 @@ ${install_packages}
 ${install_monitoring_agents}
 %{ endif ~}
 ${get_unmounted_disk}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.podman.tfe.sh.tpl
@@ -8,14 +8,12 @@ ${install_packages}
 ${install_monitoring_agents}
 %{ endif ~}
 ${get_unmounted_disk}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.ubuntu.docker.tfe.sh.tpl
@@ -8,14 +8,12 @@ ${install_packages}
 ${install_monitoring_agents}
 %{ endif ~}
 ${get_unmounted_disk}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -9,14 +9,12 @@ ${install_monitoring_agents}
 %{ if database_azure_msi_auth_enabled ~}
 ${azurerm_database_init}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -9,14 +9,12 @@ ${install_monitoring_agents}
 %{ if database_azure_msi_auth_enabled ~}
 ${azurerm_database_init}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -9,14 +9,12 @@ ${install_monitoring_agents}
 %{ if database_azure_msi_auth_enabled ~}
 ${azurerm_database_init}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if proxy_ip != null ~}
 echo "[$(date +"%FT%T")] [Terraform Enterprise] Configure proxy" | tee -a $log_pathname

--- a/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
@@ -6,6 +6,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
@@ -14,12 +15,8 @@ echo "[Terraform Enterprise] Patching GCP Yum repo configuration" | tee -a $log_
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 
-
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 docker_directory="/etc/docker"
 echo "[Terraform Enterprise] Creating Docker directory at '$docker_directory'" | tee -a $log_pathname

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -6,6 +6,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
@@ -16,10 +17,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 docker_directory="/etc/docker"
 echo "[Terraform Enterprise] Creating Docker directory at '$docker_directory'" | tee -a $log_pathname

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -6,6 +6,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
@@ -17,10 +18,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 docker_directory="/etc/docker"
 echo "[Terraform Enterprise] Creating Docker directory at '$docker_directory'" | tee -a $log_pathname

--- a/modules/tfe_init/templates/install_jq.func
+++ b/modules/tfe_init/templates/install_jq.func
@@ -1,0 +1,20 @@
+%{ if distribution == "rhel" ~}
+function install_jq {
+	local log_pathname=$1
+	# OS: RHEL/CentOS
+	# Description: Install jq JSON processor using yum package manager
+
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
+	yum install --assumeyes jq
+}
+%{ else ~}
+function install_jq {
+	local log_pathname=$1
+	# OS: Ubuntu/Debian
+	# Description: Install jq JSON processor using apt package manager
+
+	echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
+	retry 10 apt-get --assume-yes update
+	retry 10 apt-get --assume-yes install jq
+}
+%{ endif ~}

--- a/modules/tfe_init/templates/tfe.sh.tpl
+++ b/modules/tfe_init/templates/tfe.sh.tpl
@@ -7,6 +7,7 @@ ${install_packages}
 %{ if enable_monitoring ~}
 ${install_monitoring_agents}
 %{ endif ~}
+${install_jq}
 
 log_pathname="/var/log/startup.log"
 
@@ -18,10 +19,7 @@ sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
 %{ endif ~}
 
 install_packages $log_pathname
-
-echo "[$(date +"%FT%T")] [Terraform Enterprise] Install JQ" | tee -a $log_pathname
-sudo curl --noproxy '*' -Lo /bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$(uname -m | grep -q "arm\|aarch" && echo "arm64" || echo "amd64")
-sudo chmod +x /bin/jq
+install_jq $log_pathname
 
 %{ if cloud == "google" ~}
 docker_directory="/etc/docker"


### PR DESCRIPTION
## Background
This PR replaces the unreliable GitHub curl-based jq installation with native package manager installation (yum/apt) to eliminate intermittent network failures that cause TFE instance initialization to fail across AWS, GCP, and Azure environments.

## How has this been tested?
- [x] Tested the changes by deploying on AWS Ubuntu Docker first to see if it works.
- [ ] Running this against all our release tests.

## TFE Modules

### Did you add a new setting?
If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

No - This change modifies existing installation logic without adding new configuration variables or settings. The install_jq function is an internal implementation detail that doesn't expose new user-configurable options.

## This PR makes me feel
<img alt="Satisfied developer fixing a long-standing reliability issue" src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmFnN3J6MzVoZW02cjZ6bmk1NzVrNW5sa3ppeXZlNHh2N3g0bTdwYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BK0BeohHpYoBq/giphy.gif">