### PR TITLE
Added Missing `retry` func in initial script sh template

### DIFF
--- a/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/aws.rhel.docker.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.docker.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.rhel.podman.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/azurerm.ubuntu.docker.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.docker.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.rhel.podman.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}

--- a/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
+++ b/modules/tfe_init/templates/google.ubuntu.docker.tfe.sh.tpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu pipefail
 
+${retry}
 ${get_base64_secrets}
 ${install_packages}
 %{ if enable_monitoring ~}


### PR DESCRIPTION
## Background

I have added missing `retry` function at the start in initial script shell template, which was causing failures in release test.

## How has this been tested?
passed [azure release test](https://github.com/hashicorp/terraform-enterprise/actions/runs/18457952300) in my branch

## TFE Modules

### Did you add a new setting?

If no, you may delete these tasks.
If yes, please check each box after you have have added an issue in the TFE modules to add this setting:

- [ ] [AWS](https://github.com/hashicorp/terraform-aws-terraform-enterprise)
- [ ] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise)
- [ ] [GCP](https://github.com/hashicorp/terraform-google-terraform-enterprise)

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-31302)

## This PR makes me feel

![optional gif describing your feelings about this pr]()
