### PR TITLE
TF-30574: Add Azure MSI authentication support for explorer database

### DIFF
--- a/modules/runtime_container_engine_config/database_config.tf
+++ b/modules/runtime_container_engine_config/database_config.tf
@@ -17,11 +17,13 @@ locals {
   }
   database_configuration = local.disk ? {} : local.database
   explorer_database = {
-    TFE_EXPLORER_DATABASE_HOST       = var.explorer_database_host
-    TFE_EXPLORER_DATABASE_NAME       = var.explorer_database_name
-    TFE_EXPLORER_DATABASE_USER       = var.explorer_database_user
-    TFE_EXPLORER_DATABASE_PASSWORD   = var.explorer_database_password
-    TFE_EXPLORER_DATABASE_PARAMETERS = var.explorer_database_parameters
+    TFE_EXPLORER_DATABASE_HOST                         = var.explorer_database_host
+    TFE_EXPLORER_DATABASE_NAME                         = var.explorer_database_name
+    TFE_EXPLORER_DATABASE_USER                         = var.explorer_database_user
+    TFE_EXPLORER_DATABASE_PASSWORD                     = var.explorer_database_password
+    TFE_EXPLORER_DATABASE_PARAMETERS                   = var.explorer_database_parameters
+    TFE_EXPLORER_DATABASE_PASSWORDLESS_AZURE_USE_MSI   = var.explorer_database_passwordless_azure_use_msi
+    TFE_EXPLORER_DATABASE_PASSWORDLESS_AZURE_CLIENT_ID = var.explorer_database_passwordless_azure_client_id
   }
   explorer_database_configuration = var.explorer_database_host == null ? {} : local.explorer_database
 }

--- a/modules/runtime_container_engine_config/variables.tf
+++ b/modules/runtime_container_engine_config/variables.tf
@@ -136,6 +136,18 @@ variable "explorer_database_user" {
   description = "PostgreSQL user. Required when TFE_OPERATIONAL_MODE is external or active-active."
 }
 
+variable "explorer_database_passwordless_azure_use_msi" {
+  default     = false
+  type        = bool
+  description = "Whether or not to use Azure Managed Service Identity (MSI) to connect to the explorer PostgreSQL database. Defaults to false if no value is given."
+}
+
+variable "explorer_database_passwordless_azure_client_id" {
+  default     = ""
+  type        = string
+  description = "Azure Managed Service Identity (MSI) Client ID for explorer database. If not set, System Assigned Managed Identity will be used."
+}
+
 variable "disk_path" {
   default     = null
   description = "The pathname of the directory in which Terraform Enterprise will store data in Mounted Disk mode. Required when var.operational_mode is 'disk'."


### PR DESCRIPTION
## Background
This PR adds Azure MSI authentication support for the explorer database configuration. Previously, MSI auth was only available for the primary database, causing authentication failures when `explorer_database_passwordless_azure_use_msi` was enabled but the corresponding environment variables were not set.

## How has this been tested?
- Tested with Azure TFE deployment using `database_msi_auth_enabled = true` and explorer database enabled
- Verified environment variables `TFE_EXPLORER_DATABASE_PASSWORDLESS_AZURE_USE_MSI` and `TFE_EXPLORER_DATABASE_PASSWORDLESS_AZURE_CLIENT_ID` are correctly set in Docker compose configuration
- Confirmed explorer database connection succeeds using MSI authentication

## TFE Modules
### Did you add a new setting?
Yes - added two new input variables for explorer database MSI configuration:
- [x] [Azure](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise) - Updated in companion PR

## This PR makes me feel
[![Finally, feature parity!](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGIycHRid21wbmtjb2F0eGl6ZWZreXk4bWQ0NTA3Nno0em1udWdqcCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7WNhbYMIcgYn7pCzHh/giphy.gif)