### PR TITLE
fix: pin Docker to 25.0.5 for Ubuntu Replicated bootstrap installations

### DIFF
--- a/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
+++ b/modules/tfe_init_replicated/templates/tfe_replicated.sh.tpl
@@ -225,7 +225,10 @@ echo "[Terraform Enterprise] Installing Docker Engine from Repository for Bootst
 		https://download.docker.com/linux/ubuntu $(lsb_release --codename --short) stable" \
 		| sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 	apt-get --assume-yes update
-	apt-get --assume-yes install docker-ce docker-ce-cli containerd.io
+	# Pin Docker to 25.0.5 for Replicated compatibility (API version 1.44)
+	# Replicated 2.56.10 requires Docker API >= 1.44, Docker 29.x (API 1.52) causes issues
+	apt-get --assume-yes install docker-ce=5:25.0.5-1~ubuntu.22.04~jammy docker-ce-cli=5:25.0.5-1~ubuntu.22.04~jammy containerd.io
+	apt-mark hold docker-ce docker-ce-cli containerd.io
 	apt-get --assume-yes autoremove
 	%{ endif ~}
 


### PR DESCRIPTION
## Background

Pins Docker to version 25.0.5 in the Ubuntu bootstrap template. Ubuntu 24.04, while listed as supported in [TFE documentation](https://developer.hashicorp.com/terraform/enterprise/deploy/replicated/requirements/os-specific/supported-os), does not have Docker versions in the compatible range (23.x-25.x) available in the [official Docker repository.](https://download.docker.com/linux/ubuntu/dists/noble/pool/stable/amd64/)

[Ubuntu 22.04](https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/) continues to receive new Docker versions (29.x as of Jan 2026), and unpinned installations now pull Docker 29.1.4 which has API version 1.52 that is incompatible with Replicated 2.56.10 (requires API ≤ 1.44).

## How has this been tested?

Validated that unpinned Docker installation on Ubuntu 22.04 pulls version 29.1.4, causing Replicated daemon failures. Confirmed version pinning to 25.0.5 resolves the issue.

## TFE Modules

### Did you add a new setting?

No - this is a template fix, not a new configuration setting.

## This PR makes me feel

![relief](https://media.giphy.com/media/3oz8xIsloV7zOmt81G/giphy.gif)